### PR TITLE
fix: center the content

### DIFF
--- a/themes/conventional-branch/static/css/scss/base/_base.scss
+++ b/themes/conventional-branch/static/css/scss/base/_base.scss
@@ -22,6 +22,11 @@ body {
   margin-right: auto;
   padding-left: $gap-md;
   padding-right: $gap-md;
+
+}
+
+.container.markdown-body {
+  margin: 0 auto;
 }
 
 main {


### PR DESCRIPTION
The markdown body is not center aligned. Add a css style to center align the content. This bug relates to the version of `github-markdown-css` used in this project.

Closes: https://github.com/conventional-branch/conventional-branch/issues/22