### PR TITLE
Potential fix Workflow does not contain permissions

### DIFF
--- a/.github/workflows/url-check.yml
+++ b/.github/workflows/url-check.yml
@@ -2,7 +2,7 @@ name: Check Website URLs
 
 on:
   schedule:
-    - cron: '0 * * * *' # check every hour
+    - cron: '0 */4 * * *' # check every 4 hour
   workflow_dispatch: # manual trigger
 
 permissions:

--- a/.github/workflows/url-check.yml
+++ b/.github/workflows/url-check.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 * * * *' # check every hour
   workflow_dispatch: # manual trigger
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   check-urls:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/conventional-branch/conventional-branch/security/code-scanning/1](https://github.com/conventional-branch/conventional-branch/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Specifically:
- `contents: read` is needed to read repository contents.
- `issues: write` is required for the step that creates an issue if URLs fail.

The `permissions` block will be added at the root level to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
