### PR TITLE
Revise branch naming specification

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -20,7 +20,7 @@ Conventional Branch refers to a structured and standardized naming convention fo
 
 ### Branch Naming Prefixes
 
-The branch specification by describing with `feature/`, `bugfix/`, `hotfix/`, `release/` and `chore/` and it should be structured as follows:
+The branch specification supports the following prefixes and should be structured as:
 
 ---
 
@@ -29,8 +29,8 @@ The branch specification by describing with `feature/`, `bugfix/`, `hotfix/`, `r
 ```
 
 - **`main`**: The main development branch (e.g., `main`, `master`, or `develop`)
-- **`feature/`**: For new features (e.g., `feature/add-login-page`)
-- **`bugfix/`**: For bug fixes (e.g., `bugfix/fix-header-bug`)
+- **`feature/`** (or **`feat/`**): For new features (e.g., `feature/add-login-page`, `feat/add-login-page`)
+- **`bugfix/`** (or **`fix/`**): For bug fixes (e.g., `bugfix/fix-header-bug`, `fix/header-bug`)
 - **`hotfix/`**: For urgent fixes (e.g., `hotfix/security-patch`)
 - **`release/`**: For branches preparing a release (e.g., `release/v1.2.0`)
 - **`chore/`**: For non-code tasks like dependency, docs updates (e.g., `chore/update-dependencies`)


### PR DESCRIPTION
Updated branch naming prefixes for clarity and added alternative terms.

closes #64 