### PR TITLE
docs: add Traditional Chinese (zh-Hant) link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ We currently support documentation in multiple languages:
 
 [English](https://conventional-branch.github.io/) ·
 [简体中文](https://conventional-branch.github.io/zh/) ·
+[繁體中文](https://conventional-branch.github.io/zh-hant/) ·
 [日本語](https://conventional-branch.github.io/ja/) ·
 [Deutsch](https://conventional-branch.github.io/de/) ·
 [Français](https://conventional-branch.github.io/fr/) ·


### PR DESCRIPTION
## Summary
- Add missing Traditional Chinese (zh-Hant) link to the multilingual documentation section in README.md

## Context
The zh-Hant translation was merged in #98 (commit 5880c84), but the README's language list was not updated to include it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Traditional Chinese language documentation link to the multilingual documentation section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->