### PR TITLE
Fix Examples table being unreadable when browser in dark mode

### DIFF
--- a/themes/conventional-branch/static/css/scss/base/_base.scss
+++ b/themes/conventional-branch/static/css/scss/base/_base.scss
@@ -31,6 +31,12 @@ body {
   color: black !important;
 }
 
+@media (prefers-color-scheme: dark) {
+  .markdown-body > table {
+    color: index.$color-neutral-light
+  }
+}
+
 main {
   background-color: index.$main-background;
 }


### PR DESCRIPTION
Fixes #117, while preserving readability for light mode.

I kept the `.container.markdown-body` selector as is, as  that's forcing the color of the text to be black. Otherwise, it would default to white if the browser was set to dark mode, rendering the rest of the page unreadable.

# Dark mode:
| Before | After |
| ------------ | ---------- |
|![](https://github.com/user-attachments/assets/66e65b6a-59c1-4cbc-95c1-a9c89ae24f0e) |  ![](https://github.com/user-attachments/assets/f5e760a6-43da-4ef1-af3e-d5f59a2c1632) |


# Light mode:
| Before | After |
| ------------ | ---------- |
| ![](https://github.com/user-attachments/assets/a0eb083e-7369-4a49-9dbc-4f1db4455be7) | ![](https://github.com/user-attachments/assets/28bc161e-e208-4b58-b131-a4104ab567e0) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added dark mode styling for markdown tables to enhance readability and overall user experience. Tables now intelligently display with optimized text colors when dark mode is enabled on your device, providing visual consistency and ensuring comfortable viewing regardless of your preferred color scheme throughout the application interface.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/conventional-branch/conventional-branch/pull/118)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->