### PR TITLE
docs: fix broken project links and reorder for impact

### DIFF
--- a/content/about/index.md
+++ b/content/about/index.md
@@ -13,7 +13,7 @@ The Conventional Branch specification was inspired by [Conventional Commits](htt
 
 ## Projects Using Conventional Branch
 
-* [karol-broda/snitch](https://github.com/karol-broda/snitch/blob/master/CONTRIBUTING.md): A prettier way to inspect network connections (3.4k+ stars).
+* [karol-broda/snitch](https://github.com/karol-broda/snitch/blob/master/CONTRIBUTING.md): A prettier way to inspect network connections.
 * [ansible/metrics-utility](https://github.com/ansible/metrics-utility/blob/devel/docs/CONTRIBUTING.md): Standalone utility for github.com/ansible/awx.
 * [sanity-io/sdk](https://github.com/sanity-io/sdk/blob/main/CONTRIBUTING.md): Sanity App SDK.
 * [TexasInstruments/processor-sdk-doc](https://github.com/TexasInstruments/processor-sdk-doc): Texas Instruments Processor SDK documentation.

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -13,17 +13,17 @@ The Conventional Branch specification was inspired by [Conventional Commits](htt
 
 ## Projects Using Conventional Branch
 
-* [ansible/metrics-utility](https://github.com/ansible/metrics-utility/blob/devel/docs/contributing/CONTRIBUTING.md): Standalone utility for github.com/ansible/awx.
+* [karol-broda/snitch](https://github.com/karol-broda/snitch/blob/master/CONTRIBUTING.md): A prettier way to inspect network connections (3.4k+ stars).
+* [ansible/metrics-utility](https://github.com/ansible/metrics-utility/blob/devel/docs/CONTRIBUTING.md): Standalone utility for github.com/ansible/awx.
 * [sanity-io/sdk](https://github.com/sanity-io/sdk/blob/main/CONTRIBUTING.md): Sanity App SDK.
+* [TexasInstruments/processor-sdk-doc](https://github.com/TexasInstruments/processor-sdk-doc): Texas Instruments Processor SDK documentation.
+* [dunossauro/fastapi-do-zero](https://github.com/dunossauro/fastapi-do-zero/blob/main/aulas/contribua/contribua.md): Curso básico de FastAPI em português.
+* [Enedis-OSS/tic4eebus](https://github.com/Enedis-OSS/tic4eebus/blob/main/CONTRIBUTING.md): EEBUS OPEV use case by Enedis, France's largest electricity distributor.
+* [bcgov/nr-pies](https://github.com/bcgov/nr-pies): Natural Resource Permitting Information Exchange by the Government of British Columbia.
 * [commit-check](https://github.com/commit-check): A free, powerful tool that enforces commit metadata, branch naming, and more.
 * [ZeusAutomacao/DFe.NET](https://github.com/ZeusAutomacao/DFe.NET): Biblioteca em C# para emissão e impressão de NFe, NFCe, MDF-e e CT-e.
 * [RLinf/RLinf](https://github.com/RLinf/RLinf): Reinforcement Learning Infrastructure for Agentic AI.
 * [Curiosum](https://github.com/curiosum-dev): Building apps for innovators.
-* [karol-broda/snitch](https://github.com/karol-broda/snitch/blob/main/CONTRIBUTING.md): A prettier way to inspect network connections (3.4k+ stars).
-* [dunossauro/fastapi-do-zero](https://github.com/dunossauro/fastapi-do-zero/blob/main/aulas/contribua/contribua.md): Curso básico de FastAPI em português.
-* [TexasInstruments/processor-sdk-doc](https://github.com/TexasInstruments/processor-sdk-doc): Texas Instruments Processor SDK documentation.
-* [Enedis-OSS/tic4eebus](https://github.com/Enedis-OSS/tic4eebus/blob/main/CONTRIBUTING.md): EEBUS OPEV use case by Enedis, France's largest electricity distributor.
-* [bcgov/nr-pies](https://github.com/bcgov/nr-pies): Natural Resource Permitting Information Exchange by the Government of British Columbia.
 * [jal-co/shieldcn](https://github.com/jal-co/shieldcn): Beautiful README badges inspired by shadcn/ui.
 * _[... and more projects using Conventional Branch](https://github.com/search?q=conventional-branch.github.io&type=code&p=1)._
 


### PR DESCRIPTION
## Summary

Fix two broken links and reorder the "Projects Using Conventional Branch" list.

### 🔧 Fixed links
| Project | Before | After |
|---|---|---|
| `ansible/metrics-utility` | `docs/contributing/CONTRIBUTING.md` (404) | `docs/CONTRIBUTING.md` ✅ |
| `karol-broda/snitch` | `blob/main/CONTRIBUTING.md` (404) | `blob/master/CONTRIBUTING.md` ✅ |

### 📊 Reordered by significance
1. **karol-broda/snitch** (3.4k ⭐) – most popular
2. **ansible/metrics-utility** – Red Hat / Ansible
3. **sanity-io/sdk** – Sanity.io
4. **TexasInstruments/processor-sdk-doc** – Texas Instruments
5. **dunossauro/fastapi-do-zero** (~1k ⭐) – popular PT-BR course
6. **Enedis-OSS/tic4eebus** – France's largest electricity distributor
7. **bcgov/nr-pies** – Government of British Columbia
8. **commit-check** – the tool itself
9. Community projects: ZeusAutomacao, RLinf, Curiosum, shieldcn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reordered entries in the projects list to improve clarity and navigation.
  * Updated a project's documentation link to point to the refined documentation path.
  * All other surrounding content and sections were left intact; no functional or API changes were made.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/conventional-branch/conventional-branch/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->