### PR TITLE
docs: update website URL from conventional-branch.github.io to conventionalbranch.org

### DIFF
--- a/.github/workflows/url-check.yml
+++ b/.github/workflows/url-check.yml
@@ -17,19 +17,19 @@ jobs:
         id: check
         run: | # add more URLs as needed
           urls=(
-            "https://conventional-branch.github.io/"
-            "https://conventional-branch.github.io/#summary"
-            "https://conventional-branch.github.io/#specification"
-            "https://conventional-branch.github.io/about/"
-            "https://conventional-branch.github.io/de/"
-            "https://conventional-branch.github.io/es/"
-            "https://conventional-branch.github.io/fr/"
-            "https://conventional-branch.github.io/ja/"
-            "https://conventional-branch.github.io/pl/"
-            "https://conventional-branch.github.io/pt-br/"
-            "https://conventional-branch.github.io/ru/"
-            "https://conventional-branch.github.io/zh/"
-            "https://conventional-branch.github.io/zh-hant/"
+            "https://conventionalbranch.org/"
+            "https://conventionalbranch.org/#summary"
+            "https://conventionalbranch.org/#specification"
+            "https://conventionalbranch.org/about/"
+            "https://conventionalbranch.org/de/"
+            "https://conventionalbranch.org/es/"
+            "https://conventionalbranch.org/fr/"
+            "https://conventionalbranch.org/ja/"
+            "https://conventionalbranch.org/pl/"
+            "https://conventionalbranch.org/pt-br/"
+            "https://conventionalbranch.org/ru/"
+            "https://conventionalbranch.org/zh/"
+            "https://conventionalbranch.org/zh-hant/"
           )
 
           failed_urls=()

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # The Conventional Branch Specification
 
 [![Conventional Branch](https://img.shields.io/badge/Conventional%20Branch-Spec-6192c3)](https://github.com/conventional-branch/conventional-branch)
-[![Website](https://img.shields.io/website?url=https%3A%2F%2Fconventional-branch.github.io%2F&up_color=6192c3)](https://conventional-branch.github.io/)
+[![Website](https://img.shields.io/website?url=https%3A%2F%2Fconventionalbranch.org%2F&up_color=6192c3)](https://conventionalbranch.org/)
 [![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
 
 The Conventional Branch specification defines a naming convention that brings order to your development workflow — whether you're working solo or with a team.
@@ -30,17 +30,17 @@ Trunk branches (`main`, `master`, `develop`) do not require a prefix.
 
 We currently support documentation in multiple languages:
 
-[English](https://conventional-branch.github.io/) ·
-[简体中文](https://conventional-branch.github.io/zh/) ·
-[繁體中文](https://conventional-branch.github.io/zh-hant/) ·
-[日本語](https://conventional-branch.github.io/ja/) ·
-[Deutsch](https://conventional-branch.github.io/de/) ·
-[Español](https://conventional-branch.github.io/es/) ·
-[Français](https://conventional-branch.github.io/fr/) ·
-[Polski](https://conventional-branch.github.io/pl/) ·
-[Português (Brasil)](https://conventional-branch.github.io/pt-br/) ·
-[Русский](https://conventional-branch.github.io/ru/) ·
-[ภาษาไทย](https://conventional-branch.github.io/th/)
+[English](https://conventionalbranch.org/) ·
+[简体中文](https://conventionalbranch.org/zh/) ·
+[繁體中文](https://conventionalbranch.org/zh-hant/) ·
+[日本語](https://conventionalbranch.org/ja/) ·
+[Deutsch](https://conventionalbranch.org/de/) ·
+[Español](https://conventionalbranch.org/es/) ·
+[Français](https://conventionalbranch.org/fr/) ·
+[Polski](https://conventionalbranch.org/pl/) ·
+[Português (Brasil)](https://conventionalbranch.org/pt-br/) ·
+[Русский](https://conventionalbranch.org/ru/) ·
+[ภาษาไทย](https://conventionalbranch.org/th/)
 
 If your language is not listed, we welcome contributions to add it!
 

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -25,7 +25,7 @@ The Conventional Branch specification was inspired by [Conventional Commits](htt
 * [RLinf/RLinf](https://github.com/RLinf/RLinf): Reinforcement Learning Infrastructure for Agentic AI.
 * [Curiosum](https://github.com/curiosum-dev): Building apps for innovators.
 * [jal-co/shieldcn](https://github.com/jal-co/shieldcn): Beautiful README badges inspired by shadcn/ui.
-* _[... and more projects using Conventional Branch](https://github.com/search?q=conventionalbranch.org&type=code&p=1)._
+* _[... and more projects using Conventional Branch](https://github.com/search?q=conventional-branch.github.io&type=code&p=1)._
 
 [![Conventional Branch](https://img.shields.io/badge/Conventional%20Branch-Spec-6192c3)](https://github.com/conventional-branch/conventional-branch)
 

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -25,7 +25,7 @@ The Conventional Branch specification was inspired by [Conventional Commits](htt
 * [RLinf/RLinf](https://github.com/RLinf/RLinf): Reinforcement Learning Infrastructure for Agentic AI.
 * [Curiosum](https://github.com/curiosum-dev): Building apps for innovators.
 * [jal-co/shieldcn](https://github.com/jal-co/shieldcn): Beautiful README badges inspired by shadcn/ui.
-* _[... and more projects using Conventional Branch](https://github.com/search?q=conventional-branch.github.io&type=code&p=1)._
+* _[... and more projects using Conventional Branch](https://github.com/search?q=conventionalbranch.org&type=code&p=1)._
 
 [![Conventional Branch](https://img.shields.io/badge/Conventional%20Branch-Spec-6192c3)](https://github.com/conventional-branch/conventional-branch)
 

--- a/skills/conventional-branch/SKILL.md
+++ b/skills/conventional-branch/SKILL.md
@@ -5,13 +5,13 @@ license: CC BY 4.0
 compatibility: "Requires git. Optional: commit-check for automated branch name validation."
 metadata:
   version: "1.0.0"
-  spec: https://conventional-branch.github.io
+  spec: https://conventionalbranch.org
   source: https://github.com/conventional-branch/conventional-branch
 ---
 
 # Conventional Branch
 
-Create Git branches that follow the [Conventional Branch 1.0.0](https://conventional-branch.github.io) specification — human-readable, machine-parseable, and automation-friendly.
+Create Git branches that follow the [Conventional Branch 1.0.0](https://conventionalbranch.org) specification — human-readable, machine-parseable, and automation-friendly.
 
 ## Branch Name Format
 

--- a/static/README.md
+++ b/static/README.md
@@ -1,6 +1,6 @@
 # Conventional Branch Static Site
 
-[![Website](https://img.shields.io/static/v1?label=Website&message=conventional-branch.github.io&color=6192c3)](https://conventional-branch.github.io/)
+[![Website](https://img.shields.io/static/v1?label=Website&message=conventionalbranch.org&color=6192c3)](https://conventionalbranch.org/)
 
 Welcome to the Conventional Branch static site repository!
 

--- a/themes/conventional-branch/README.md
+++ b/themes/conventional-branch/README.md
@@ -4,7 +4,7 @@ Copy hugo-conventional-branch-theme inside your my-hugo-site/theme
 ## config.yaml example
 All config params are optionals.
 ```yaml
-baseURL: 'https://conventional-branch.github.io/'
+baseURL: 'https://conventionalbranch.org/'
 languageCode: en-us
 title: Conventional Branch
 theme: conventional-branch
@@ -27,7 +27,7 @@ params:
     image: 'https://path-to-image'
     actions:
     - label: Read the specs
-      url: 'https://conventional-branch.github.io/'
+      url: 'https://conventionalbranch.org/'
     - label: GitHub
       url: 'https://github.com/conventional-branch/conventional-branch'
 


### PR DESCRIPTION
## Summary

The new domain https://conventionalbranch.org is now live. This PR updates all references from `conventional-branch.github.io` to `conventionalbranch.org`.

Fixes  #60 

## Changes

| File | Change |
|------|--------|
| `README.md` | Website badge + 11 language links |
| `static/README.md` | Website badge |
| `themes/conventional-branch/README.md` | Example `baseURL` and `url` |
| `content/about/index.md` | GitHub search link |
| `skills/conventional-branch/SKILL.md` | Spec URL (metadata + body) |
| `.github/workflows/url-check.yml` | All 13 URL check entries |

## Note

The `external_repository` in `.github/workflows/main.yml` was **not** changed because it refers to the GitHub Pages repository name (`conventional-branch/conventional-branch.github.io`), not the domain. This should stay as-is unless the repo has been renamed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated website links and references across README files and documentation to point to the new `conventionalbranch.org` domain.

* **Chores**
  * Updated automated URL monitoring workflow to use the new domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->