### PR TITLE
fix: add retry logic to URL check workflow to reduce 503 false positives

### DIFF
--- a/.github/workflows/url-check.yml
+++ b/.github/workflows/url-check.yml
@@ -32,13 +32,28 @@ jobs:
             "https://conventionalbranch.org/zh-hant/"
           )
 
+          max_retries=3
+          retry_delay=15  # seconds between retries
           failed_urls=()
 
           for url in "${urls[@]}"; do
             echo "Checking $url"
-            status=$(curl -o /dev/null -s -w "%{http_code}\n" "$url")
-            if [[ "$status" -ne 200 ]]; then
-              echo "$url failed with status $status"
+            success=false
+            for ((i=1; i<=max_retries; i++)); do
+              status=$(curl -o /dev/null -s -w "%{http_code}\n" "$url")
+              if [[ "$status" -eq 200 ]]; then
+                echo "  OK (HTTP $status)"
+                success=true
+                break
+              fi
+              if [[ $i -lt $max_retries ]]; then
+                echo "  Attempt $i/$max_retries: HTTP $status - retrying in ${retry_delay}s..."
+                sleep $retry_delay
+              else
+                echo "  Attempt $i/$max_retries: HTTP $status - giving up"
+              fi
+            done
+            if [[ "$success" == false ]]; then
               failed_urls+=("$url (HTTP $status)")
             fi
           done


### PR DESCRIPTION
## Summary

URL check workflow (`.github/workflows/url-check.yml`) currently sends a single curl request per URL. When GitHub Pages returns a transient **503**, it immediately reports the URL as unreachable and creates an issue — even though the site recovers seconds later.

## Changes

- Added retry loop: **up to 3 attempts** with **15 seconds** delay between each
- Only marks a URL as failed if all 3 retries return non-200
- Adds clear per-attempt logging for debugging

## Behavior

```
Checking https://conventionalbranch.org/about/
  Attempt 1/3: HTTP 503 - retrying in 15s...
  Attempt 2/3: HTTP 200 - OK
```

Only after 3 consecutive failures (~45 seconds of downtime) will an issue be created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * URL check workflow now retries non-200 HTTP responses up to a configurable limit with delays between attempts, improving reliability by reducing false failures from transient network issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->