### PR TITLE
docs: add optional AI agent actor prefix to the spec

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -57,13 +57,13 @@ AI coding agents increasingly create branches automatically, and several tools a
 | Devin | `devin/` | `devin/1712345678-fix-login` |
 | Claude (community convention) | `claude/` | `claude/update-readme` |
 
-To capture **who** created a branch (a human or a specific agent), an optional *actor* segment may be prefixed directly before the description:
+To capture **who** created a branch (a human or a specific agent), an optional *actor* segment may lead the branch name, directly before the description:
 
 ```text
 <actor>/<description>
 ```
 
-The actor **replaces** the type prefix rather than nesting with it: a branch name carries either a `<type>/` prefix or an `<actor>/` prefix, not both. This mirrors what agents emit in practice (e.g. `copilot/add-theme-switcher`).
+For agent-created branches, the actor takes the place of the type segment: where a conventional branch reads `<type>/<description>`, an agent branch reads `<actor>/<description>`. This mirrors what agents emit in practice (e.g. `copilot/add-theme-switcher`) — the convention simply adapts the familiar `<type>/<description>` shape to record the author instead of the change kind.
 
 Rules for the actor segment:
 
@@ -104,7 +104,7 @@ actor-branch    = actor "/" description
 actor           = 1*(ALPHA / DIGIT) *("-" 1*(ALPHA / DIGIT))  ; a declared actor id
 ```
 
-> Note: Consecutive hyphens or dots, and hyphens or dots at the start or end of the description, are not permitted. The `actor-branch` rule is an opt-in extension: an actor segment is valid only when declared by the project (see [AI Agent Prefixes](#ai-agent-prefixes-optional)); undeclared prefixes remain invalid.
+> Note: Consecutive hyphens or dots, and hyphens or dots at the start or end of the description, are not permitted. The `actor-branch` rule is an opt-in extension: an actor segment is recognized only when declared by the project (see [AI Agent Prefixes](#ai-agent-prefixes-optional)); undeclared prefixes remain invalid.
 
 ### Examples
 
@@ -129,7 +129,6 @@ actor           = 1*(ALPHA / DIGIT) *("-" 1*(ALPHA / DIGIT))  ; a declared actor
 | `feature/-new-login` | ❌ | Leading hyphen in description |
 | `feature/new-login-` | ❌ | Trailing hyphen in description |
 | `release/v1.-2.0` | ❌ | Hyphen adjacent to dot |
-| `claude/feature/login-page` | ❌ | Actor and type cannot be combined; use `claude/login-page` |
 | `fix/header bug` | ❌ | Spaces not allowed |
 | `fix/header_bug` | ❌ | Underscores not allowed |
 | `unknown/some-task` | ❌ | Unknown prefix: not a type, and not a declared actor |

--- a/content/_index.md
+++ b/content/_index.md
@@ -24,7 +24,7 @@ The branch specification supports the following prefixes and should be structure
 
 ---
 
-```
+```text
 <type>/<description>
 ```
 
@@ -57,17 +57,13 @@ AI coding agents increasingly create branches automatically, and several tools a
 | Devin | `devin/` | `devin/1712345678-fix-login` |
 | Claude (community convention) | `claude/` | `claude/update-readme` |
 
-To capture **who** created a branch (a human or a specific agent) alongside **what** it does, an optional *actor* segment may be prefixed to a branch name:
+To capture **who** created a branch (a human or a specific agent), an optional *actor* segment may be prefixed directly before the description:
 
-```
-<actor>/<type>/<description>
-```
-
-The intermediate `<type>` is **optional**, because most agents today emit `<actor>/<description>` directly:
-
-```
+```text
 <actor>/<description>
 ```
+
+The actor **replaces** the type prefix rather than nesting with it: a branch name carries either a `<type>/` prefix or an `<actor>/` prefix, not both. This mirrors what agents emit in practice (e.g. `copilot/add-theme-switcher`).
 
 Rules for the actor segment:
 
@@ -90,13 +86,11 @@ Other actors a project may choose to recognize include `devin`, `aider`, `codex`
 
 ### Formal Grammar
 
-The following Augmented Backus-Naur Form (ABNF) grammar formally defines valid branch names. The `actor-branch` rule is the optional extension described in [AI Agent Prefixes](#ai-agent-prefixes-optional); when no actors are declared, only `trunk-branch` and `prefixed-branch` apply.
+The following Augmented Backus-Naur Form (ABNF) grammar formally defines valid branch names. The core grammar is `trunk-branch` and `prefixed-branch`. The `actor-branch` rule is the optional extension described in [AI Agent Prefixes](#ai-agent-prefixes-optional) and applies **only when a project declares actors**.
 
 ```abnf
-branch-name     = trunk-branch / prefixed-branch / actor-branch
+branch-name     = trunk-branch / prefixed-branch
 trunk-branch    = "main" / "master" / "develop"
-actor-branch    = actor "/" ( prefixed-branch / description )
-actor           = 1*(ALPHA / DIGIT) *("-" 1*(ALPHA / DIGIT))  ; a declared actor id
 prefixed-branch = type "/" description
 type            = "feature" / "feat" / "bugfix" / "fix"
                 / "hotfix" / "release" / "chore"
@@ -104,9 +98,13 @@ description     = desc-segment *("-" desc-segment)
 desc-segment    = 1*(ALPHA / DIGIT) *("." 1*(ALPHA / DIGIT))
 ALPHA           = %x61-7A   ; lowercase a-z
 DIGIT           = %x30-39   ; 0-9
+
+; Optional extension — only when a project declares actors (see "AI Agent Prefixes"):
+actor-branch    = actor "/" description
+actor           = 1*(ALPHA / DIGIT) *("-" 1*(ALPHA / DIGIT))  ; a declared actor id
 ```
 
-> Note: Consecutive hyphens or dots, and hyphens or dots at the start or end of the description, are not permitted. The `actor` segment is only valid when declared by the project (see [AI Agent Prefixes](#ai-agent-prefixes-optional)); undeclared prefixes remain invalid.
+> Note: Consecutive hyphens or dots, and hyphens or dots at the start or end of the description, are not permitted. The `actor-branch` rule is an opt-in extension: an actor segment is valid only when declared by the project (see [AI Agent Prefixes](#ai-agent-prefixes-optional)); undeclared prefixes remain invalid.
 
 ### Examples
 
@@ -125,13 +123,13 @@ DIGIT           = %x30-39   ; 0-9
 | `feature/issue-123-new-login` | ✅ | Feature with ticket number |
 | `copilot/add-theme-switcher` | ✅ | Optional actor + description (`copilot` declared) |
 | `cursor/refactor-cache-layer` | ✅ | Optional actor + description (`cursor` declared) |
-| `claude/feature/login-page` | ✅ | Optional actor + type + description |
-| `human/fix/header-bug` | ✅ | Explicit human actor (optional) |
+| `human/fix-header-bug` | ✅ | Explicit human actor (optional) |
 | `Feature/Add-Login` | ❌ | Uppercase letters not allowed |
 | `feature/new--login` | ❌ | Consecutive hyphens not allowed |
 | `feature/-new-login` | ❌ | Leading hyphen in description |
 | `feature/new-login-` | ❌ | Trailing hyphen in description |
 | `release/v1.-2.0` | ❌ | Hyphen adjacent to dot |
+| `claude/feature/login-page` | ❌ | Actor and type cannot be combined; use `claude/login-page` |
 | `fix/header bug` | ❌ | Spaces not allowed |
 | `fix/header_bug` | ❌ | Underscores not allowed |
 | `unknown/some-task` | ❌ | Unknown prefix: not a type, and not a declared actor |

--- a/content/_index.md
+++ b/content/_index.md
@@ -44,13 +44,59 @@ The branch specification supports the following prefixes and should be structure
 3. **Keep It Clear and Concise**: The branch name should be descriptive yet concise, clearly indicating the purpose of the work.
 4. **Include Ticket Numbers**: If applicable, include the ticket number from your project management tool to make tracking easier. For example, for a ticket `issue-123`, the branch name could be `feature/issue-123-new-login`.
 
+### AI Agent Prefixes (Optional)
+
+> This is an **optional, opt-in extension**. Projects that do not enable it see no change in behavior, and every existing branch name remains valid.
+
+AI coding agents increasingly create branches automatically, and several tools already namespace those branches with their own prefix:
+
+| Agent | Prefix | Example |
+|---|---|---|
+| GitHub Copilot coding agent | `copilot/` | `copilot/add-theme-switcher` |
+| Cursor (background / cloud agent) | `cursor/` | `cursor/refactor-cache-layer` |
+| Devin | `devin/` | `devin/1712345678-fix-login` |
+| Claude (community convention) | `claude/` | `claude/update-readme` |
+
+To capture **who** created a branch (a human or a specific agent) alongside **what** it does, an optional *actor* segment may be prefixed to a branch name:
+
+```
+<actor>/<type>/<description>
+```
+
+The intermediate `<type>` is **optional**, because most agents today emit `<actor>/<description>` directly:
+
+```
+<actor>/<description>
+```
+
+Rules for the actor segment:
+
+1. **Opt-in and declared**: A project must declare the actors it recognizes. Undeclared first segments remain invalid (so `unknown/some-task` is still rejected), which keeps the convention strict by default. With no actors configured, the specification behaves exactly as before.
+2. **`human` is implicit**: Omitting the actor segment implies a human author; `human/` need not be written explicitly. Existing `<type>/<description>` names are therefore unchanged.
+3. **Open, not hardcoded**: The specification defines the actor *mechanism* and offers a recommended list; it does not bake vendor names into the grammar. Projects declare their own set as new agents emerge.
+4. **Same character rules**: An actor follows the same conventions as other segments — lowercase letters, digits, and internal hyphens.
+
+A project might, for example, declare:
+
+```yaml
+actors:
+  - human
+  - copilot
+  - cursor
+  - claude
+```
+
+Other actors a project may choose to recognize include `devin`, `aider`, `codex`, and `jules`.
+
 ### Formal Grammar
 
-The following Augmented Backus-Naur Form (ABNF) grammar formally defines valid branch names:
+The following Augmented Backus-Naur Form (ABNF) grammar formally defines valid branch names. The `actor-branch` rule is the optional extension described in [AI Agent Prefixes](#ai-agent-prefixes-optional); when no actors are declared, only `trunk-branch` and `prefixed-branch` apply.
 
 ```abnf
-branch-name     = trunk-branch / prefixed-branch
+branch-name     = trunk-branch / prefixed-branch / actor-branch
 trunk-branch    = "main" / "master" / "develop"
+actor-branch    = actor "/" ( prefixed-branch / description )
+actor           = 1*(ALPHA / DIGIT) *("-" 1*(ALPHA / DIGIT))  ; a declared actor id
 prefixed-branch = type "/" description
 type            = "feature" / "feat" / "bugfix" / "fix"
                 / "hotfix" / "release" / "chore"
@@ -60,7 +106,7 @@ ALPHA           = %x61-7A   ; lowercase a-z
 DIGIT           = %x30-39   ; 0-9
 ```
 
-> Note: Consecutive hyphens or dots, and hyphens or dots at the start or end of the description, are not permitted.
+> Note: Consecutive hyphens or dots, and hyphens or dots at the start or end of the description, are not permitted. The `actor` segment is only valid when declared by the project (see [AI Agent Prefixes](#ai-agent-prefixes-optional)); undeclared prefixes remain invalid.
 
 ### Examples
 
@@ -77,6 +123,10 @@ DIGIT           = %x30-39   ; 0-9
 | `release/v1.2.0` | ✅ | Release with version |
 | `chore/update-dependencies` | ✅ | Non-code task |
 | `feature/issue-123-new-login` | ✅ | Feature with ticket number |
+| `copilot/add-theme-switcher` | ✅ | Optional actor + description (`copilot` declared) |
+| `cursor/refactor-cache-layer` | ✅ | Optional actor + description (`cursor` declared) |
+| `claude/feature/login-page` | ✅ | Optional actor + type + description |
+| `human/fix/header-bug` | ✅ | Explicit human actor (optional) |
 | `Feature/Add-Login` | ❌ | Uppercase letters not allowed |
 | `feature/new--login` | ❌ | Consecutive hyphens not allowed |
 | `feature/-new-login` | ❌ | Leading hyphen in description |
@@ -84,7 +134,7 @@ DIGIT           = %x30-39   ; 0-9
 | `release/v1.-2.0` | ❌ | Hyphen adjacent to dot |
 | `fix/header bug` | ❌ | Spaces not allowed |
 | `fix/header_bug` | ❌ | Underscores not allowed |
-| `unknown/some-task` | ❌ | Unknown prefix type |
+| `unknown/some-task` | ❌ | Unknown prefix: not a type, and not a declared actor |
 
 ## Conclusion
 
@@ -111,6 +161,10 @@ You can use [commit-check](https://github.com/commit-check/commit-check) to chec
 ### Can I define my own branch types beyond the ones listed?
 
 Yes. The specification defines a recommended set of types, but teams can define additional custom types to fit their workflow. It is important, however, to document custom types clearly so that all team members and automated tooling are aware of them.
+
+### Should I use the optional AI agent actor prefix?
+
+Only if your team wants to distinguish human-created branches from agent-created ones. The actor prefix is an opt-in extension: it is useful for traceability, auditing, and AI contribution metrics in workflows that mix human and AI-generated branches, but it adds no value—and should be left disabled—for teams that do not need it. When enabled, declare the exact set of actors you recognize so that unexpected prefixes are still flagged.
 
 ### How does Conventional Branch relate to Conventional Commits?
 


### PR DESCRIPTION
Closes #136

## What

Adds an **optional, opt-in** *actor* segment to the Conventional Branch spec, recording **who** created a branch (a human or a specific AI coding agent), leading the branch name directly before the description:

```
<actor>/<description>
```

For agent-created branches, the actor takes the place of the type segment: where a conventional branch reads `<type>/<description>`, an agent branch reads `<actor>/<description>`. This adapts the familiar shape to what tools like Copilot and Cursor emit today (`copilot/add-theme-switcher`).

## Why

AI agents already namespace their branches in the wild:

| Agent | Prefix | Example |
|---|---|---|
| GitHub Copilot coding agent | `copilot/` | `copilot/add-theme-switcher` |
| Cursor (background / cloud agent) | `cursor/` | `cursor/refactor-cache-layer` |
| Devin | `devin/` | `devin/1712345678-fix-login` |
| Claude (community convention) | `claude/` | `claude/update-readme` |

This PR standardizes that emerging practice rather than inventing something new.

## Design decisions

- **`<actor>/<description>`** — the actor occupies the position the `<type>` normally would. The spec defines and recommends this single shape; it does not pass judgement on other forms.
- **Opt-in / declared actors, not globally open.** If any first segment were treated as an actor, `unknown/some-task` (currently invalid) would become valid and gut the spec's strictness. So actors must be *declared* per project; with none configured, behavior is identical to today.
- **`human` is implicit** — omitting the actor means a human author, so all existing `<type>/<description>` names stay valid. Fully backward compatible.
- **No vendor names hardcoded in the grammar** — the spec defines the mechanism plus a non-normative recommended list; projects declare their own set.
- **`actor-branch` is kept out of the core `branch-name` rule** and presented as a clearly-marked opt-in extension, so the base grammar doesn't read as unconditional support.

## Changes

English spec only (`content/_index.md`):
- New **"AI Agent Prefixes (Optional)"** section with the vendor table, rules, and an example `actors:` config.
- Updated ABNF grammar: core grammar unchanged; `actor-branch` / `actor` added as a separate optional-extension block.
- New example rows for valid actor branches.
- New FAQ entry: "Should I use the optional AI agent actor prefix?"

## Follow-ups (intentionally out of scope)

- Translations: the other `content/_index.*.md` files (zh, zh-hant, ja, de, es, fr, pl, pt-br, ru, th).
- Optional README quick-start mention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced the branch naming specification with an optional AI Agent actor prefix segment (e.g., `copilot/`, `cursor/`) and an explicit `human/` example
  * Expanded the formal grammar to support actor-prefixed branch names, with actor prefixes only allowed when declared
  * Updated examples to include new valid formats and additional invalid cases (formatting violations and unknown/undeclared actor prefixes)
  * Added FAQ guidance on when to use actor prefixes and reiterated the opt-in/declaration requirement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->