### PR TITLE
feat: improve visual quality and reading experience

### DIFF
--- a/themes/conventional-branch/layouts/partials/head.html
+++ b/themes/conventional-branch/layouts/partials/head.html
@@ -9,6 +9,10 @@
     gtag('config', 'G-RH9YBHW509');
   </script>
   
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+
   <link rel="stylesheet" href="{{ .Site.BaseURL }}css/style.css">
 
   <title>{{ .Param "Title" }}</title>

--- a/themes/conventional-branch/static/css/scss/abstracts/_mixins.scss
+++ b/themes/conventional-branch/static/css/scss/abstracts/_mixins.scss
@@ -18,8 +18,8 @@
   }
 }
 
-@mixin gradient-primary($deg: 45deg) {
-  background: linear-gradient($deg, variables.$color-primary 0%, variables.$color-primary-light 100%);
+@mixin gradient-primary($deg: 150deg) {
+  background: linear-gradient($deg, variables.$color-primary-deep 0%, variables.$color-primary 100%);
 }
 
 @mixin dropdown-animation-visible {

--- a/themes/conventional-branch/static/css/scss/abstracts/_variables.scss
+++ b/themes/conventional-branch/static/css/scss/abstracts/_variables.scss
@@ -1,9 +1,14 @@
 $color-primary: #6699CC;
 $color-primary-light: #6699CC;
+$color-primary-deep: #3B6BB5;
 $color-neutral-light: #FFF;
 $color-neutral-dark: #000;
 
-$color-primary-heading: #7fa5ec;
+$color-primary-heading: #2B5EA7;
+$color-primary-heading-sub: #3D6FB8;
+
+$font-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+$font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', 'Consolas', 'Monaco', monospace;
 
 $gap-sm: 8px;
 $gap-md: 24px;
@@ -12,7 +17,7 @@ $gap-lg: 48px;
 $radius-md: 4px;
 $radius-lg: 8px;
 
-$shadow-soft: 0 2px 10px 0 rgba(0, 0, 0, .03), 0 2px 20px 10px rgba(0, 0, 0, 0.02);
+$shadow-soft: 0 1px 3px rgba(0, 0, 0, 0.06), 0 4px 16px rgba(0, 0, 0, 0.08), 0 8px 32px rgba(0, 0, 0, 0.04);
 
 $mobile-width: 350px;
 $tablet-width: 768px;

--- a/themes/conventional-branch/static/css/scss/base/_base.scss
+++ b/themes/conventional-branch/static/css/scss/base/_base.scss
@@ -1,5 +1,13 @@
 @use "./../abstracts/index";
 
+html {
+  scroll-behavior: smooth;
+
+  @media (prefers-reduced-motion: reduce) {
+    scroll-behavior: auto;
+  }
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -12,7 +20,10 @@
 body {
   position: relative;
   min-height: 100vh;
-  font: 16px Helvetica, sans-serif;
+  font-family: index.$font-sans;
+  font-size: 16px;
+  line-height: 1.65;
+  color: #1a1a1a;
 }
 
 .container {
@@ -58,8 +69,8 @@ article {
   }
 
   article {
-    padding-top: index.$gap-lg - index.$gap-sm;
-    padding-bottom: index.$gap-lg - index.$gap-sm;
+    padding-top: index.$gap-lg;
+    padding-bottom: index.$gap-lg;
   }
 }
 

--- a/themes/conventional-branch/static/css/scss/layout/_welcome.scss
+++ b/themes/conventional-branch/static/css/scss/layout/_welcome.scss
@@ -36,15 +36,20 @@
 
   &__title {
     font-size: 2.6em;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    line-height: 1.15;
     margin-bottom: index.$gap-sm;
 
     @include index.up-to-mobile {
       word-break: break-all;
+      letter-spacing: -0.01em;
     }
 
     @include index.desktop {
       width: 85%;
       font-size: 3.6em;
+      letter-spacing: -0.03em;
     }
   }
 

--- a/themes/conventional-branch/static/css/scss/themes/_markdown.scss
+++ b/themes/conventional-branch/static/css/scss/themes/_markdown.scss
@@ -1,14 +1,50 @@
 @use "./../abstracts/index";
 
 main article.markdown-body {
-  h1{
-    font-size: 2.3em;
+  line-height: 1.75;
+
+  p {
+    margin-bottom: 1.1em;
   }
-  h1, h2, h3, h4, h5, h6, a {
-    font-weight: bold;
+
+  h1 {
+    font-size: 2.3em;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    line-height: 1.2;
+    color: index.$color-primary-heading;
+    margin-bottom: 0.5em;
+  }
+
+  h2 {
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    line-height: 1.3;
     color: index.$color-primary-heading;
   }
+
+  h3, h4, h5, h6 {
+    font-weight: 600;
+    color: index.$color-primary-heading-sub;
+  }
+
+  a {
+    color: index.$color-primary-heading;
+    &:hover {
+      color: index.$color-primary;
+    }
+  }
+
   a.anchorjs-link:hover {
     text-decoration: none;
+  }
+
+  code, pre, kbd, samp {
+    font-family: index.$font-mono;
+  }
+
+  pre code {
+    font-size: 0.9em;
+    line-height: 1.6;
   }
 }


### PR DESCRIPTION
## Summary

- **Font upgrade**: Added Inter (body) and JetBrains Mono (code) via Google Fonts, replacing Helvetica for consistent cross-platform rendering
- **Hero gradient**: Changed from flat `#6699CC` to a real gradient `#3B6BB5 → #6699CC` at 150°, adding visual depth
- **Typography refinement**: Body line-height 1.65, article content line-height 1.75; large headings get `letter-spacing` for optical compensation; heading colors split into two tiers (h1/h2 vs h3-h6), both passing WCAG AA contrast
- **Shadow upgrade**: Article card shadow upgraded from near-invisible single layer to a three-layer refined shadow
- **UX details**: Smooth scroll with `prefers-reduced-motion` support, desktop article padding increased to 48px

## Files Changed

| File | Change |
|------|--------|
| `head.html` | Add Google Fonts preconnect + Inter + JetBrains Mono |
| `_variables.scss` | Add `$color-primary-deep`, `$color-primary-heading-sub`, font variables; update shadow and heading color |
| `_mixins.scss` | `gradient-primary` now uses a real deep-to-light gradient at 150° |
| `_base.scss` | Use Inter font family, add `line-height`, `color`, smooth scroll, increase article padding |
| `_welcome.scss` | Hero title gets `font-weight: 700`, `letter-spacing`, and tighter `line-height` |
| `_markdown.scss` | Rewrite: split h1/h2/h3-h6 color tiers, explicit code font, improved line-height and paragraph spacing |

## Test plan

- [ ] Run `npm run build` in `themes/conventional-branch/` and confirm SCSS compiles without errors
- [ ] Run `hugo server` and check `http://localhost:1313`
- [ ] Confirm Hero renders the deep-to-brand-blue gradient
- [ ] Confirm body font loads as Inter (DevTools → Network → Fonts)
- [ ] Confirm code blocks render in JetBrains Mono
- [ ] Confirm h1/h2 and h3-h6 have distinct color tiers
- [ ] Switch language versions (zh, ja, etc.) and confirm styling is consistent
- [ ] Check responsive layout on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)