### PR TITLE
docs: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Conventional Branch specification will be documented 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [1.1.0] - Unreleased
+## [1.1.0] - 2026-07-08
 
 ### Added
 - **AI Agent Source Prefixes**: `ai/`, `copilot/`, `cursor/`, `claude/`, `codex/` for identifying AI-generated branches.
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated ABNF grammar to include AI agent source types.
 - Updated examples table with AI agent branch name examples.
 - Version switcher UI on the specification website.
+- **AI agent prefix registry**: a machine-readable `data/agents.yaml` rendered as a table across all languages, with a documented process for registering new agent prefixes.
+- **Machine-readable specification**: `spec.json` (types, aliases, rules, ABNF grammar, and a validation regex) served at [conventionalbranch.org/spec.json](https://conventionalbranch.org/spec.json), plus language-agnostic conformance fixtures and a CI check that keeps the spec, docs, and registry in sync.
 
 ## [1.0.0] - 2026-06-20
 
@@ -38,4 +40,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Specification established as industry-standard with dedicated website at [conventionalbranch.org](https://conventionalbranch.org) (2026-04).
 - Versioned content structure with version switcher UI for browsing spec versions (2026-06).
 
+[1.1.0]: https://github.com/conventional-branch/conventional-branch/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/conventional-branch/conventional-branch/releases/tag/v1.0.0


### PR DESCRIPTION
## Summary

Finalizes the CHANGELOG for the **v1.1.0** release. The spec, skill, `spec.json`, and site config already pin `1.1.0`; the only thing left marked "Unreleased" was the changelog itself.

## Changes

- Date the `[1.1.0]` entry: `Unreleased` → `2026-07-08`.
- Record the two additions that shipped during this release cycle:
  - the **AI agent prefix registry** (`data/agents.yaml` + rendered table), and
  - the **machine-readable `spec.json` + conformance suite**.
- Add the `v1.0.0...v1.1.0` compare link.

## Verification

- No remaining "Unreleased" markers anywhere in the repo.
- Version pins are consistent: `config.yaml` (`current: v1.1.0`), `static/spec.json` (`"version": "1.1.0"`), `skills/.../SKILL.md` (`version: "1.1.0"`).
- `tests/conformance.py` still passes.

## Follow-up after merge (the actual "release" action)

The compare link and `1.0.0` link both point at **git tags** (`v1.1.0`, `v1.0.0`). This PR does not create the tag — tagging/publishing a GitHub Release is a repo-level action, not a file change. Once this merges I can create the `v1.1.0` tag on the merge commit and open a GitHub Release with these notes (or you can). Say the word and I'll do it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NHCozYS4WsBWnnHzLLNwj

---
_Generated by [Claude Code](https://claude.ai/code/session_019NHCozYS4WsBWnnHzLLNwj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Finalized the `1.1.0` release notes and replaced the previous “Unreleased” section.
  * Added details about new AI agent branch identification capabilities, including a prefix registry and a machine-readable specification.
  * Noted published locations, conformance fixtures, and a CI synchronization check.
  * Added a new version comparison link for `v1.1.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->