### PR TITLE
docs: surface adopters list in README, document contribution process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,16 @@ Guidelines for a good prefix:
 - It must satisfy the branch-name grammar: lowercase `a-z`, digits, no separators.
 - Prefer registering a dedicated prefix over overloading `ai/`, which stays reserved as the vendor-neutral fallback.
 
+### Adding your project to the adopters list
+
+The "Projects Using Conventional Branch" list on the [About page](./content/about/index.md) is the canonical record of adopters, and a condensed excerpt is mirrored in the README's "Used By" section.
+
+To add your project:
+
+1. Add a bullet to the list in `./content/about/index.md`, linking to the file where your project documents the convention (e.g. your `CONTRIBUTING.md`) and a short one-line description.
+2. Keep the list roughly in the order projects were added (new entries at the bottom, before the "and more" link).
+3. Open a pull request. If your project is widely recognizable, it may also be added to the shorter curated list in `README.md`, at the maintainers' discretion.
+
 ### Changing the grammar or types
 
 The specification has a machine-readable form in [`./static/spec.json`](./static/spec.json) (types, rules, ABNF, and a validation regex) with conformance cases in [`./tests/fixtures.json`](./tests/fixtures.json). If you change the grammar, the types, or the examples table, update `spec.json` and the fixtures to match and run:

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ The specification is published in a machine-readable form so tools don't have to
 
 A [conformance test](tests/README.md) runs in CI and checks the fixtures, the examples table in the docs, and the agent registry all against `spec.json`, so they can't drift apart.
 
+## 🏢 Used By
+
+Projects and organizations adopting Conventional Branch, including [Ledger](https://github.com/LedgerHQ/ledger-live), [Sanity](https://github.com/sanity-io/sdk), [Ansible](https://github.com/ansible/metrics-utility), [Texas Instruments](https://github.com/TexasInstruments/processor-sdk-doc), and the [Government of British Columbia](https://github.com/bcgov/nr-pies). See the [full list](https://conventionalbranch.org/about/#projects-using-conventional-branch) and add your project via pull request.
+
 ## 🎉 Show Your Support
 
 If you find this useful, consider giving it a ⭐️ on [GitHub](https://github.com/conventional-branch/conventional-branch)! Your support helps others discover and adopt the spec.


### PR DESCRIPTION
## Summary
- Add a "Used By" section to `README.md` highlighting a few recognizable adopters (Ledger, Sanity, Ansible, Texas Instruments, BC Government), linking to the full list on the website's About page — the README previously had no link to that page at all.
- Document in `CONTRIBUTING.md` how projects can add themselves to the adopters list, mirroring the existing process docs for tooling and AI agent prefixes.

## Test plan
- [x] Verified the linked anchor (`https://conventionalbranch.org/about/#projects-using-conventional-branch`) matches the existing "Projects Using Conventional Branch" heading in `content/about/index.md`.
- [x] Reviewed rendered Markdown diff for both files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BudWCHvNNE2HPG5wY5PET1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded contribution guidance with instructions for adding projects to the adopters list.
  * Added a “Used By” section to the README featuring examples of projects using the specification.
  * Included links to the complete adopter list and instructions for suggesting additional projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->