### PR TITLE
ci: auto-close url-check issues once URLs recover

### DIFF
--- a/.github/workflows/url-check.yml
+++ b/.github/workflows/url-check.yml
@@ -115,14 +115,14 @@ jobs:
           script: |
             const title = '🚨 Some URLs are not reachable';
 
-            const existingIssues = await github.rest.issues.listForRepo({
+            const existingIssues = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
               labels: 'url-check'
             });
 
-            for (const issue of existingIssues.data.filter(issue => issue.title === title)) {
+            for (const issue of existingIssues.filter(issue => issue.title === title && !issue.pull_request)) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/url-check.yml
+++ b/.github/workflows/url-check.yml
@@ -107,3 +107,33 @@ jobs:
             } else {
               console.log('Issue already exists, skipping creation.');
             }
+
+      - name: Close resolved issues
+        if: steps.check.outputs.has_failed == 'false'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const title = '🚨 Some URLs are not reachable';
+
+            const existingIssues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'url-check'
+            });
+
+            for (const issue of existingIssues.data.filter(issue => issue.title === title)) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: 'All tracked URLs are reachable again — closing automatically.'
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'completed'
+              });
+            }


### PR DESCRIPTION
## Summary
- Fixes #124: the `url-check.yml` workflow only ever opened an issue when a URL check failed; once the URL recovered, nothing closed the issue on a later successful run.
- Adds a "Close resolved issues" step that runs when all URL checks pass, finds any open `url-check`-labeled issue with the matching title, comments, and closes it.

## Test plan
- [x] Reviewed the new step's logic against the existing "Create Issue if URLs failed" step for consistent owner/repo/label usage.
- [ ] Workflow only runs on schedule/`workflow_dispatch`, so behavior will be confirmed on the next scheduled run (or can be triggered manually via `workflow_dispatch`) after merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BudWCHvNNE2HPG5wY5PET1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically closes URL-reachability alerts once the previously failing URLs are reachable again.
  * Adds a recovery comment to the related open alert before closing it.
* **Automation / Maintenance**
  * Enhances the URL-check workflow to locate the relevant open alerts and close only the matching items after successful reachability checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->