### PR TITLE
ci: pin workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Validate spec.json is valid JSON

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
       - name: Validate spec.json is valid JSON

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           submodules: recursive
@@ -52,12 +52,12 @@ jobs:
         run: make all
       - name: Upload artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ./public
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@329bcc8f12caed2cefe5a5b80781499a6f3b361b # v4
+        uses: peaceiris/actions-gh-pages@329bcc8f12caed2cefe5a5b80781499a6f3b361b # v4.1.0
         # If you're changing the branch from main,
         # also change the `main` in `refs/heads/main`
         # below accordingly.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           submodules: recursive
           fetch-depth: 0
@@ -51,12 +51,12 @@ jobs:
         run: make all
       - name: Upload artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: ./public
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@329bcc8f12caed2cefe5a5b80781499a6f3b361b # v4
         # If you're changing the branch from main,
         # also change the `main` in `refs/heads/main`
         # below accordingly.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           submodules: recursive
           fetch-depth: 0
       - name: Install Node.js dependencies

--- a/.github/workflows/ods-validate.yml
+++ b/.github/workflows/ods-validate.yml
@@ -15,13 +15,13 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
 
       - name: ODS AI code quality gate
-        uses: open-delivery-spec/validate-action@v1
+        uses: open-delivery-spec/validate-action@850c35b20de6fc343505760995c64bf4beff428d # v1
         with:
           diff-base: ${{ github.event.pull_request.base.sha || 'origin/main' }}
           branch: ${{ github.head_ref }}

--- a/.github/workflows/ods-validate.yml
+++ b/.github/workflows/ods-validate.yml
@@ -15,14 +15,14 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 0
           ref: ${{ github.head_ref }}
 
       - name: ODS AI code quality gate
-        uses: open-delivery-spec/validate-action@850c35b20de6fc343505760995c64bf4beff428d # v1
+        uses: open-delivery-spec/validate-action@850c35b20de6fc343505760995c64bf4beff428d # v0.2.4
         with:
           diff-base: ${{ github.event.pull_request.base.sha || 'origin/main' }}
           branch: ${{ github.head_ref }}

--- a/.github/workflows/ods-validate.yml
+++ b/.github/workflows/ods-validate.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           fetch-depth: 0
           ref: ${{ github.head_ref }}
 

--- a/.github/workflows/url-check.yml
+++ b/.github/workflows/url-check.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Create Issue if URLs failed
         if: steps.check.outputs.has_failed == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           script: |
             const fs = require('fs');
@@ -110,7 +110,7 @@ jobs:
 
       - name: Close resolved issues
         if: steps.check.outputs.has_failed == 'false'
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           script: |
             const title = '🚨 Some URLs are not reachable';

--- a/.github/workflows/url-check.yml
+++ b/.github/workflows/url-check.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Create Issue if URLs failed
         if: steps.check.outputs.has_failed == 'true'
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -110,7 +110,7 @@ jobs:
 
       - name: Close resolved issues
         if: steps.check.outputs.has_failed == 'false'
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9.0.0
         with:
           script: |
             const title = '🚨 Some URLs are not reachable';


### PR DESCRIPTION
## Summary

- pin every GitHub Action used by the workflows to an immutable commit SHA
- preserve the release tag in a trailing comment for maintenance visibility
- keep the change limited to `.github/workflows/`

Closes #161

## Validation

- parsed all four workflow files with PyYAML
- checked that every `uses:` reference has a full 40-character commit SHA
- confirmed the referenced SHAs resolve from the upstream action tags with `git ls-remote`
- `git diff --check`

This change was prepared with AI assistance and reviewed manually against the repository's requested format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned automated workflow actions to immutable versions for more consistent and secure builds.
  * Disabled persisted credentials during checkout steps.
  * Preserved existing validation, deployment, artifact handling, and URL-check behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->