### PR TITLE
ci: persist checkout credentials for ODS validate workflow

### DIFF
--- a/.github/workflows/ods-validate.yml
+++ b/.github/workflows/ods-validate.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: false
+          persist-credentials: true
           fetch-depth: 0
           ref: ${{ github.head_ref }}
 


### PR DESCRIPTION
## What

Reverts my earlier refactor of the ODS Validate workflow back to its original state, keeping a single change: `persist-credentials: false` → `true` in the checkout step.

## Change

```diff
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: false
+          persist-credentials: true
           fetch-depth: 0
           ref: ${{ github.head_ref }}
```

Everything else (checkout `ref`, `comment: 'true'`, pinned SHAs from #162) is unchanged.

## Note

This restores the pre-#162 credential behavior for this workflow (the token is persisted into the workspace git config for later steps in the job). Per the discussion on #162, the fork-PR checkout failure there was a ref-resolution issue (`A branch or tag with the name '...' could not be found` — the head branch only exists in the fork), which `persist-credentials` does not affect; fork PRs are not part of this change's scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated validation workflows to preserve Git credentials during checkout.
  * This improves the reliability of repository access while running pull request validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->