### PR TITLE
docs: surface the adopters that make the case, and add fifteen more

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,8 +52,8 @@ The "Projects Using Conventional Branch" list on the [About page](./content/abou
 
 To add your project:
 
-1. Add a bullet to the list in `./content/about/index.md`, linking to the file where your project documents the convention (e.g. your `CONTRIBUTING.md`) and a short one-line description.
-2. Keep the list roughly in the order projects were added (new entries at the bottom, before the "and more" link).
+1. Add a bullet to the list in `./content/about/index.md`, linking to the file where your project documents the convention (e.g. your `CONTRIBUTING.md`) and a short one-line description. The link must point at a file that actually documents the convention — the list is evidence, not a directory.
+2. The list is roughly ordered by how widely recognized the organization is, so that it stays useful to skim. Add your entry wherever it fits; maintainers may move it.
 3. Open a pull request. If your project is widely recognizable, it may also be added to the shorter curated list in `README.md`, at the maintainers' discretion.
 
 ### Changing the grammar or types

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Conventional Branch defines a small branch naming convention, `<type>/<description>`, in which every branch declares its own purpose. That turns a branch name into something your CI/CD pipelines, review policies, and tooling can act on directly, instead of a team habit that has to be explained to each new contributor and enforced by hand in code review.
 
-The convention is published as a [machine-readable spec](#-machine-readable-spec) with conformance fixtures, so validating branch names is a solved problem for any tool that wants to support it. It is used by [Ledger](https://github.com/LedgerHQ/ledger-live), [Sanity](https://github.com/sanity-io/sdk), [Ansible](https://github.com/ansible/metrics-utility), and the [Government of British Columbia](https://github.com/bcgov/nr-pies), among [others](#-used-by).
+The convention is published as a [machine-readable spec](#-machine-readable-spec) with conformance fixtures, so validating branch names is a solved problem for any tool that wants to support it. It is used by the UK's [GCHQ](https://github.com/gchq/Bailo/blob/main/AGENTS.md), [Oak Ridge National Laboratory](https://github.com/ORNLSlicer/ORNLSlicer/blob/develop/docs/contributing/conventional-branch.md), [ByteDance](https://github.com/ByteDance-Seed/cryofm/blob/main/CONTRIBUTING.md), the [Government of British Columbia](https://github.com/bcgov/nr-pies), [Ledger](https://github.com/LedgerHQ/ledger-live), and [LiteLLM](https://github.com/BerriAI/litellm), among [others](#-used-by).
 
 ## 🚀 Quick Start
 
@@ -79,7 +79,7 @@ A [conformance test](tests/README.md) runs in CI and checks the fixtures, the ex
 
 ## 🏢 Used By
 
-Alongside the projects named above, Conventional Branch is adopted by [Texas Instruments](https://github.com/TexasInstruments/processor-sdk-doc) and [LiteLLM](https://github.com/BerriAI/litellm), among others. See the [full list](https://conventionalbranch.org/about/#projects-using-conventional-branch) and add your project via pull request.
+Alongside the organizations named above, Conventional Branch is adopted by [Texas Instruments](https://github.com/TexasInstruments/processor-sdk-doc), [Ansible](https://github.com/ansible/metrics-utility), [Sanity](https://github.com/sanity-io/sdk), Portugal's state technology agency [ARTE](https://github.com/amagovpt/udata-pt), and [Enedis](https://github.com/Enedis-OSS/tic4eebus), France's largest electricity distributor. See the [full list](https://conventionalbranch.org/about/#projects-using-conventional-branch) and add your project via pull request.
 
 ## 🎉 Show Your Support
 

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -28,20 +28,38 @@ Building an agent that opens PRs? [Register its prefix](https://github.com/conve
 
 ## Projects Using Conventional Branch
 
+Roughly ordered by how widely recognized the organization is, so the list is useful
+to skim.
+
+* [gchq/Bailo](https://github.com/gchq/Bailo/blob/main/AGENTS.md): Machine learning lifecycle management, by GCHQ, the UK's intelligence, security and cyber agency.
+* [ORNLSlicer/ORNLSlicer](https://github.com/ORNLSlicer/ORNLSlicer/blob/develop/docs/contributing/conventional-branch.md): Toolpath planning and slicing for additive manufacturing, developed at Oak Ridge National Laboratory.
+* [ByteDance-Seed/cryofm](https://github.com/ByteDance-Seed/cryofm/blob/main/CONTRIBUTING.md): Generative foundation model for cryo-EM density maps, by ByteDance Seed.
+* [bcgov/nr-pies](https://github.com/bcgov/nr-pies): Natural Resource Permitting Information Exchange by the Government of British Columbia.
+* [amagovpt/udata-pt](https://github.com/amagovpt/udata-pt/blob/main/CLAUDE.md): Portugal's open data platform, by ARTE, the state agency for technological reform.
+* [TexasInstruments/processor-sdk-doc](https://github.com/TexasInstruments/processor-sdk-doc): Texas Instruments Processor SDK documentation.
+* [Enedis-OSS/tic4eebus](https://github.com/Enedis-OSS/tic4eebus/blob/main/CONTRIBUTING.md): EEBUS OPEV use case by Enedis, France's largest electricity distributor.
+* [LedgerHQ/ledger-live](https://github.com/LedgerHQ/ledger-live/blob/main/CONTRIBUTING.md): Mono-repository for packages related to Ledger Live and its JavaScript ecosystem.
 * [BerriAI/litellm](https://github.com/BerriAI/litellm/blob/main/CONTRIBUTING.md): A high-performance LLM proxy supporting 100+ models with spending tracking and guardrails.
-* [karol-broda/snitch](https://github.com/karol-broda/snitch/blob/master/CONTRIBUTING.md): A prettier way to inspect network connections.
 * [ansible/metrics-utility](https://github.com/ansible/metrics-utility/blob/devel/docs/CONTRIBUTING.md): Standalone utility for github.com/ansible/awx.
 * [sanity-io/sdk](https://github.com/sanity-io/sdk/blob/main/CONTRIBUTING.md): Sanity App SDK.
-* [TexasInstruments/processor-sdk-doc](https://github.com/TexasInstruments/processor-sdk-doc): Texas Instruments Processor SDK documentation.
-* [dunossauro/fastapi-do-zero](https://github.com/dunossauro/fastapi-do-zero/blob/main/aulas/contribua/contribua.md): Curso básico de FastAPI em português.
-* [Enedis-OSS/tic4eebus](https://github.com/Enedis-OSS/tic4eebus/blob/main/CONTRIBUTING.md): EEBUS OPEV use case by Enedis, France's largest electricity distributor.
-* [bcgov/nr-pies](https://github.com/bcgov/nr-pies): Natural Resource Permitting Information Exchange by the Government of British Columbia.
-* [commit-check](https://github.com/commit-check): A free, powerful tool that enforces commit metadata, branch naming, and more.
-* [ZeusAutomacao/DFe.NET](https://github.com/ZeusAutomacao/DFe.NET): Biblioteca em C# para emissão e impressão de NFe, NFCe, MDF-e e CT-e.
-* [RLinf/RLinf](https://github.com/RLinf/RLinf): Reinforcement Learning Infrastructure for Agentic AI.
+* [cuga-project/cuga-agent](https://github.com/cuga-project/cuga-agent/blob/main/CONTRIBUTING.md): CUGA, an open-source generalist agent harness for the enterprise.
+* [TailGrids/tailgrids](https://github.com/TailGrids/tailgrids/blob/main/CONTRIBUTING.md): Open-source React UI library built with Tailwind CSS.
+* [lightonai/lighton-python-sdk](https://github.com/lightonai/lighton-python-sdk/blob/main/CONTRIBUTING.md): Python SDK for the LightOn API.
+* [ippontech/iroco2](https://github.com/ippontech/iroco2/blob/main/contribute/CONTRIBUTING.md): IroCO2, a tool for estimating and reducing the carbon footprint of cloud infrastructure, by Ippon Technologies.
+* [Technica-Engineering/FLYNC](https://github.com/Technica-Engineering/FLYNC/blob/main/CONTRIBUTING.md): Flexible YAML-based vehicle network configuration, by Technica Engineering.
+* [stellio-hub/stellio-context-broker](https://github.com/stellio-hub/stellio-context-broker/blob/develop/docs/contributing/development_guide.md): Stellio, an NGSI-LD compatible context broker.
 * [Curiosum](https://github.com/curiosum-dev): Building apps for innovators.
+* [ZeusAutomacao/DFe.NET](https://github.com/ZeusAutomacao/DFe.NET): Biblioteca em C# para emissão e impressão de NFe, NFCe, MDF-e e CT-e.
+* [commit-check](https://github.com/commit-check): A free, powerful tool that enforces commit metadata, branch naming, and more.
+* [fau-advanced-separations/CADET-Process](https://github.com/fau-advanced-separations/CADET-Process/blob/dev/CONTRIBUTING.md): A framework for modelling and optimizing advanced chromatographic processes, by Advanced Separations @ FAU.
+* [devsoc-unsw/structs.sh](https://github.com/devsoc-unsw/structs.sh/blob/dev/docs/docs/contributing.md): An educational data structures and algorithms platform, by the UNSW Software Development Society.
+* [CSES-Open-Source/TritonScript](https://github.com/CSES-Open-Source/TritonScript/blob/main/CONTRIBUTING.md): Open source project by the Computer Science and Engineering Society at UC San Diego.
+* [RLinf/RLinf](https://github.com/RLinf/RLinf): Reinforcement Learning Infrastructure for Agentic AI.
+* [soma-smart/framefox](https://github.com/soma-smart/framefox/blob/main/CONTRIBUTING.md): Python web framework built on FastAPI, MVC and SQLModel.
+* [keyteki/keyteki](https://github.com/keyteki/keyteki/blob/master/AGENTS.md): The engine behind The Crucible Online, for playing KeyForge in the browser.
+* [karol-broda/snitch](https://github.com/karol-broda/snitch/blob/master/CONTRIBUTING.md): A prettier way to inspect network connections.
 * [jal-co/shieldcn](https://github.com/jal-co/shieldcn): Beautiful README badges inspired by shadcn/ui.
-* [LedgerHQ/ledger-live](https://github.com/LedgerHQ/ledger-live/blob/main/CONTRIBUTING.md): Mono-repository for packages related to Ledger Live and its JavaScript ecosystem.
+* [dunossauro/fastapi-do-zero](https://github.com/dunossauro/fastapi-do-zero/blob/main/aulas/contribua/contribua.md): Curso básico de FastAPI em português.
 * _[... and more projects using Conventional Branch](https://github.com/search?q=conventional-branch.github.io&type=code&p=1)._
 
 [![Conventional Branch](https://conventionalbranch.org/badge.svg)](https://conventionalbranch.org/)


### PR DESCRIPTION
The adopters list was ordered by when each project was added, so the names carrying the most weight were scattered through it, and the README named four of them almost at random. Someone deciding whether to adopt a specification reads that list as evidence — it should lead with its strongest evidence.

## How these were found

GitHub code search for `conventionalbranch.org` and `conventional-branch.github.io` returned **157 unique repositories**. Every candidate below was then verified by fetching the file and reading the sentence around the reference — a search hit alone is not evidence of adoption.

## Added

**Institutions**

| Adopter | Evidence |
|---|---|
| **GCHQ** — the UK's intelligence, security and cyber agency | [`gchq/Bailo` AGENTS.md](https://github.com/gchq/Bailo/blob/main/AGENTS.md): "Use [conventional branch names](https://conventionalbranch.org/): `<type>/<description>`" |
| **Oak Ridge National Laboratory** | [`ORNLSlicer` has a dedicated page](https://github.com/ORNLSlicer/ORNLSlicer/blob/develop/docs/contributing/conventional-branch.md) for it: "This project uses the Conventional Branch specification for branch names." |
| **ByteDance Seed** | [`cryofm` CONTRIBUTING.md](https://github.com/ByteDance-Seed/cryofm/blob/main/CONTRIBUTING.md): "This project recommends following the Conventional Branch specification" |
| **ARTE** — Portugal's state agency for technological reform | [`amagovpt/udata-pt` CLAUDE.md](https://github.com/amagovpt/udata-pt/blob/main/CLAUDE.md): "All contributors must follow these conventions." (also in `dadosgov-fe`) |

**Companies and projects**

CUGA, TailGrids, LightOn, Ippon Technologies (IroCO2), Technica Engineering (FLYNC), Stellio, Advanced Separations @ FAU (CADET-Process), UNSW Software Development Society (structs.sh), UC San Diego CSES (TritonScript), framefox, and The Crucible Online (keyteki).

The list goes from 14 entries to 29.

## Deliberately not added

- **[ruanyf/weekly](https://github.com/ruanyf/weekly)** (100k ⭐) featured the specification in [issue 377](https://github.com/ruanyf/weekly/blob/master/docs/issue-377.md). That is coverage, not adoption, and putting it under "Projects Using" would be a false claim.
- **[SchemaStore](https://github.com/SchemaStore/schemastore)** (3.8k ⭐) references the specification in `src/schemas/json/commit-check.json` — but that is commit-check's schema, and commit-check is already listed. Worth knowing the spec is reachable from the catalog VS Code and JetBrains read, but it is not an adopter.
- **willowtreeapps** — the reference is in an interview-exercise repo and mislabels the link as Conventional Commits.

## Reordering

The list is now roughly ordered by how widely recognized the organization is, with a one-line note saying so at the top.

`CONTRIBUTING.md` is updated to match, and now also states that an entry must link to a file that actually documents the convention — **the list is evidence, not a directory**. That rule is what made the three exclusions above obvious.

## Also changed

- README opening now names GCHQ, Oak Ridge National Laboratory, ByteDance, the Government of British Columbia, Ledger, and LiteLLM.
- README "Used By" names the next tier rather than repeating LiteLLM.

## Verification

- All **43** GitHub links across the changed files return 200 — checked individually.
- For each of the 15 new entries, the linked file was fetched and confirmed to contain the reference (not just the repository).
- `hugo` build renders 30 list items on the About page (29 adopters + the "and more" line).
- `python3 tests/conformance.py` passes.

The org profile README gets the same lineup in conventional-branch/.github#5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated contribution guidance for ordering adopter-list entries and linking to relevant convention documentation.
  - Refreshed adoption references in the README with additional organizations and projects.
  - Expanded and reorganized the “Projects Using Conventional Branch” section, including new project listings and clearer ordering guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->