### PR TITLE
feat: publish copy-pasteable enforcement configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - **Permanent spec endpoint**: the machine-readable spec is now served both at [`/spec.json`](https://conventionalbranch.org/spec.json) (always the latest version) and at [`/v1.1.0/spec.json`](https://conventionalbranch.org/v1.1.0/spec.json), frozen at publication. Downstream tools can pin the versioned URL so a future release cannot change their behavior unannounced.
 - **JSON Schema for `spec.json`**: [`/schema/v1/spec.schema.json`](https://conventionalbranch.org/schema/v1/spec.schema.json) describes the structure of the spec document itself, with written stability guarantees for each endpoint. `spec.json` now carries a `$schema` key.
-- **Enforcement page** at [conventionalbranch.org/enforce](https://conventionalbranch.org/enforce/): copy-pasteable configuration for GitHub rulesets, GitHub Actions, GitLab push rules and CI, Bitbucket Pipelines, pre-commit, a dependency-free Git hook, branch-creation aliases, and a snippet for `AGENTS.md` / `CLAUDE.md`. A conformance check keeps every regex on it identical to `spec.json`.
+- **Enforcement page** at [conventionalbranch.org/enforce](https://conventionalbranch.org/enforce/): copy-pasteable configuration for GitHub rulesets, GitHub Actions, GitLab push rules and CI, Bitbucket Pipelines, a dependency-free Git hook, branch-creation aliases, and a snippet for `AGENTS.md` / `CLAUDE.md`. A conformance check keeps every regex on it identical to `spec.json`.
 - Two conformance checks covering the above: every published spec document is validated against the schema, and a release cannot ship without a byte-identical frozen copy of the version it declares.
 
 ## [1.1.0] - 2026-07-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - **Permanent spec endpoint**: the machine-readable spec is now served both at [`/spec.json`](https://conventionalbranch.org/spec.json) (always the latest version) and at [`/v1.1.0/spec.json`](https://conventionalbranch.org/v1.1.0/spec.json), frozen at publication. Downstream tools can pin the versioned URL so a future release cannot change their behavior unannounced.
 - **JSON Schema for `spec.json`**: [`/schema/v1/spec.schema.json`](https://conventionalbranch.org/schema/v1/spec.schema.json) describes the structure of the spec document itself, with written stability guarantees for each endpoint. `spec.json` now carries a `$schema` key.
+- **Enforcement page** at [conventionalbranch.org/enforce](https://conventionalbranch.org/enforce/): copy-pasteable configuration for GitHub rulesets, GitHub Actions, GitLab push rules and CI, Bitbucket Pipelines, pre-commit, a dependency-free Git hook, branch-creation aliases, and a snippet for `AGENTS.md` / `CLAUDE.md`. A conformance check keeps every regex on it identical to `spec.json`.
 - Two conformance checks covering the above: every published spec document is validated against the schema, and a release cannot ship without a byte-identical frozen copy of the version it declares.
 
 ## [1.1.0] - 2026-07-08

--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ The specification is published in a machine-readable form so tools don't have to
 
 A [conformance test](tests/README.md) runs in CI and checks the fixtures, the examples table in the docs, the agent registry, and every published spec document against `spec.json` and its schema, so they can't drift apart. The [stability guarantees](tests/README.md#endpoints-and-stability) for each endpoint are written down.
 
+## ⚙️ Enforcing It
+
+Copy-pasteable configuration for GitHub rulesets, GitLab push rules, Bitbucket
+Pipelines, pre-commit, a dependency-free Git hook, branch-creation aliases, and a
+snippet for `AGENTS.md` / `CLAUDE.md`, at
+[conventionalbranch.org/enforce](https://conventionalbranch.org/enforce/). Every regex on
+that page is the one in `spec.json`, checked in CI, so the configuration cannot go stale.
+
 ## 🏢 Used By
 
 Alongside the organizations named above, Conventional Branch is adopted by [Texas Instruments](https://github.com/TexasInstruments/processor-sdk-doc), [Ansible](https://github.com/ansible/metrics-utility), [Sanity](https://github.com/sanity-io/sdk), Portugal's state technology agency [ARTE](https://github.com/amagovpt/udata-pt), and [Enedis](https://github.com/Enedis-OSS/tic4eebus), France's largest electricity distributor. See the [full list](https://conventionalbranch.org/about/#projects-using-conventional-branch) and add your project via pull request.

--- a/README.md
+++ b/README.md
@@ -80,10 +80,11 @@ A [conformance test](tests/README.md) runs in CI and checks the fixtures, the ex
 ## ⚙️ Enforcing It
 
 Copy-pasteable configuration for GitHub rulesets, GitLab push rules, Bitbucket
-Pipelines, pre-commit, a dependency-free Git hook, branch-creation aliases, and a
+Pipelines, a dependency-free Git hook, branch-creation aliases, and a
 snippet for `AGENTS.md` / `CLAUDE.md`, at
 [conventionalbranch.org/enforce](https://conventionalbranch.org/enforce/). Every regex on
-that page is the one in `spec.json`, checked in CI, so the configuration cannot go stale.
+that page is the one in `spec.json`, enforced by the conformance check, so a config
+copied from it cannot drift from the specification.
 
 ## 🏢 Used By
 

--- a/content/enforce/index.md
+++ b/content/enforce/index.md
@@ -182,34 +182,10 @@ pipelines:
 
 ## Local checks
 
-### pre-commit
-
-[commit-check](https://github.com/commit-check/commit-check) validates branch names as a
-`pre-commit` hook:
-
-```yaml
-repos:
-  - repo: https://github.com/commit-check/commit-check
-    rev: v2.15.0
-    hooks:
-      - id: check-branch
-```
-
-```bash
-pre-commit install
-```
-
-As of `v2.15.0` its defaults are deliberately broader than this specification — it also
-allows `docs/`, `ci/`, `refactor/` and other commit types as branch prefixes — and it
-does not yet enforce the rules on the description, so `feature/new--login` and
-`fix/header_bug` pass. If you need the specification exactly, use the server-side rule
-above, or the hook below, as the authority. Progress on closing the gap is tracked in
-[commit-check#550](https://github.com/commit-check/commit-check/issues/550).
-
 ### A hook with no dependencies
 
-If you would rather not add a tool, `pre-push` is the last local moment where a bad
-branch name can still be caught. Save this as `.git/hooks/pre-push` and make it
+`pre-push` is the last local moment where a bad branch name can still be caught,
+and this needs nothing installed. Save this as `.git/hooks/pre-push` and make it
 executable:
 
 ```bash

--- a/content/enforce/index.md
+++ b/content/enforce/index.md
@@ -14,11 +14,16 @@ teams want one of each: the server rule is the contract, the local check is the
 courtesy.
 
 Every regular expression below is the one published in
-[`spec.json`](https://conventionalbranch.org/spec.json), copied verbatim. A conformance
-check in CI fails the build if this page and the specification ever disagree, so nothing
-here can go stale. The expression is deliberately written in a portable subset — no
-backreferences, no lookaround — so it compiles under RE2 as well as PCRE, which is what
-lets the same string work in GitHub, GitLab, Python, JavaScript, and Go alike.
+[`spec.json`](https://conventionalbranch.org/spec.json), copied verbatim, and a
+conformance check fails the build if this page and the specification ever disagree. The
+expression is deliberately written in a portable subset — no backreferences, no
+lookaround — so it compiles under RE2 as well as PCRE, which is what lets the same
+string work in GitHub, GitLab, Python, JavaScript, and Go alike.
+
+That check covers the expressions, not the prose. What each platform charges for, and
+which of them can block a push rather than merely report one, is true as written but
+verified by hand — if you find it out of date, please
+[say so](https://github.com/conventional-branch/conventional-branch/issues).
 
 It already permits `main`, `master` and `develop` unprefixed, so you do not need to
 carve out exceptions for your trunk branches.
@@ -27,8 +32,8 @@ carve out exceptions for your trunk branches.
 
 ### Rulesets
 
-Rulesets are the only GitHub feature that rejects a non-conforming branch outright. The
-`branch_name_pattern` rule takes a regular expression directly.
+A ruleset rejects a non-conforming branch outright, and on github.com it is the only
+thing that does. The `branch_name_pattern` rule takes a regular expression directly.
 
 ```json
 {
@@ -179,8 +184,8 @@ pipelines:
 
 ### pre-commit
 
-[commit-check](https://github.com/commit-check/commit-check) ships this specification's
-branch types as its defaults, so enabling the hook is the whole configuration:
+[commit-check](https://github.com/commit-check/commit-check) validates branch names as a
+`pre-commit` hook:
 
 ```yaml
 repos:
@@ -193,6 +198,13 @@ repos:
 ```bash
 pre-commit install
 ```
+
+As of `v2.15.0` its defaults are deliberately broader than this specification — it also
+allows `docs/`, `ci/`, `refactor/` and other commit types as branch prefixes — and it
+does not yet enforce the rules on the description, so `feature/new--login` and
+`fix/header_bug` pass. If you need the specification exactly, use the server-side rule
+above, or the hook below, as the authority. Progress on closing the gap is tracked in
+[commit-check#550](https://github.com/commit-check/commit-check/issues/550).
 
 ### A hook with no dependencies
 
@@ -259,8 +271,9 @@ npx skills add conventional-branch/conventional-branch --skill conventional-bran
 
 ### A snippet for `AGENTS.md` or `CLAUDE.md`
 
-This is how most projects using the specification instruct their agents. Paste it into
-whichever instruction file your tooling reads:
+Several projects on the [adopters list](https://conventionalbranch.org/about/#projects-using-conventional-branch)
+already document the convention this way rather than for people. Paste it into whichever
+instruction file your tooling reads:
 
 ```markdown
 ## Branch naming

--- a/content/enforce/index.md
+++ b/content/enforce/index.md
@@ -1,0 +1,299 @@
+---
+type: about
+draft: false
+---
+
+# Enforcing Conventional Branch
+
+Copy-pasteable configuration for validating branch names against the specification.
+
+Enforcement happens at two layers, and they solve different problems. A **server-side**
+rule cannot be bypassed, but the contributor only finds out when they push. A **local**
+check is instant and can be run before a branch exists, but anyone can skip it. Most
+teams want one of each: the server rule is the contract, the local check is the
+courtesy.
+
+Every regular expression below is the one published in
+[`spec.json`](https://conventionalbranch.org/spec.json), copied verbatim. A conformance
+check in CI fails the build if this page and the specification ever disagree, so nothing
+here can go stale. The expression is deliberately written in a portable subset — no
+backreferences, no lookaround — so it compiles under RE2 as well as PCRE, which is what
+lets the same string work in GitHub, GitLab, Python, JavaScript, and Go alike.
+
+It already permits `main`, `master` and `develop` unprefixed, so you do not need to
+carve out exceptions for your trunk branches.
+
+## GitHub
+
+### Rulesets
+
+Rulesets are the only GitHub feature that rejects a non-conforming branch outright. The
+`branch_name_pattern` rule takes a regular expression directly.
+
+```json
+{
+  "name": "Conventional Branch",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~ALL"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "branch_name_pattern",
+      "parameters": {
+        "name": "Branch names must follow the Conventional Branch specification",
+        "negate": false,
+        "operator": "regex",
+        "pattern": "^(?:main|master|develop|(?:feature|feat|bugfix|fix|hotfix|release|chore|ai|copilot|cursor|claude|codex)/[a-z0-9]+(?:\\.[a-z0-9]+)*(?:-[a-z0-9]+(?:\\.[a-z0-9]+)*)*)$"
+      }
+    }
+  ]
+}
+```
+
+Save it as `conventional-branch.json` and import it under **Settings → Rules → Rulesets
+→ New ruleset → Import a ruleset**, or apply it from the command line:
+
+```bash
+gh api repos/OWNER/REPO/rulesets --method POST --input conventional-branch.json
+```
+
+Start with `"enforcement": "evaluate"` to see what the rule would have rejected without
+blocking anyone, then switch to `"active"`.
+
+Rulesets are available on public repositories with every plan, and on private
+repositories with GitHub Pro, Team, and Enterprise Cloud.
+
+### GitHub Actions
+
+A pull request check, for when a ruleset is not an option or you want the failure
+explained in the PR:
+
+```yaml
+name: Branch name
+
+on: pull_request
+
+jobs:
+  conventional-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate the branch name
+        env:
+          BRANCH: ${{ github.head_ref }}
+        run: |
+          curl -sSfLo spec.json https://conventionalbranch.org/v1.1.0/spec.json
+          python3 - <<'PY'
+          import json, os, re, sys
+
+          spec = json.load(open("spec.json"))
+          branch = os.environ["BRANCH"]
+
+          if re.fullmatch(spec["grammar"]["regex"], branch):
+              print(f"{branch}: ok")
+              sys.exit(0)
+
+          types = ", ".join(f"{t['type']}/" for t in spec["types"])
+          print(f"::error::'{branch}' does not follow the Conventional Branch "
+                f"specification. Expected <type>/<description>, where type is one "
+                f"of: {types}. See https://conventionalbranch.org/")
+          sys.exit(1)
+          PY
+```
+
+The URL is the version-pinned one on purpose: a future release of the specification
+cannot change what your pipeline accepts until you choose to bump it.
+
+## GitLab
+
+Push rules reject the branch at `pre-receive`, before it reaches the server.
+
+Under **Settings → Repository → Push rules → Branch name**, paste:
+
+```text
+^(?:main|master|develop|(?:feature|feat|bugfix|fix|hotfix|release|chore|ai|copilot|cursor|claude|codex)/[a-z0-9]+(?:\.[a-z0-9]+)*(?:-[a-z0-9]+(?:\.[a-z0-9]+)*)*)$
+```
+
+Three things worth knowing before you rely on it:
+
+- **Push rules require GitLab Premium or Ultimate.** On the Free tier, use the CI job
+  below instead.
+- GitLab evaluates the expression in multiline mode. It makes no difference to a branch
+  name, which cannot contain a newline, but if you ever extend the pattern you can turn
+  it off with a leading `(?-m)`.
+- Your default branch is always allowed, whether or not the pattern matches it.
+
+For the Free tier, the same check as a CI job:
+
+```yaml
+conventional-branch:
+  image: python:3-alpine
+  rules:
+    - if: $CI_MERGE_REQUEST_SOURCE_BRANCH_NAME
+  script:
+    - apk add --no-cache curl
+    - curl -sSfLo spec.json https://conventionalbranch.org/v1.1.0/spec.json
+    - |
+      python3 -c '
+      import json, os, re, sys
+      spec = json.load(open("spec.json"))
+      branch = os.environ["CI_MERGE_REQUEST_SOURCE_BRANCH_NAME"]
+      if not re.fullmatch(spec["grammar"]["regex"], branch):
+          sys.exit(f"{branch} does not follow https://conventionalbranch.org/")
+      print(f"{branch}: ok")
+      '
+```
+
+## Bitbucket
+
+Bitbucket **Data Center** runs pre-receive hooks, so the rule can be enforced on the
+server. Bitbucket **Cloud** does not run arbitrary server-side hooks — the check has to
+live in Pipelines, which means it reports a failure rather than refusing the push.
+
+```yaml
+pipelines:
+  pull-requests:
+    '**':
+      - step:
+          name: Branch name
+          image: python:3-alpine
+          script:
+            - apk add --no-cache curl
+            - curl -sSfLo spec.json https://conventionalbranch.org/v1.1.0/spec.json
+            - |
+              python3 -c '
+              import json, os, re, sys
+              spec = json.load(open("spec.json"))
+              branch = os.environ["BITBUCKET_BRANCH"]
+              if not re.fullmatch(spec["grammar"]["regex"], branch):
+                  sys.exit(f"{branch} does not follow https://conventionalbranch.org/")
+              print(f"{branch}: ok")
+              '
+```
+
+## Local checks
+
+### pre-commit
+
+[commit-check](https://github.com/commit-check/commit-check) ships this specification's
+branch types as its defaults, so enabling the hook is the whole configuration:
+
+```yaml
+repos:
+  - repo: https://github.com/commit-check/commit-check
+    rev: v2.15.0
+    hooks:
+      - id: check-branch
+```
+
+```bash
+pre-commit install
+```
+
+### A hook with no dependencies
+
+If you would rather not add a tool, `pre-push` is the last local moment where a bad
+branch name can still be caught. Save this as `.git/hooks/pre-push` and make it
+executable:
+
+```bash
+#!/bin/sh
+# Reject a push from a branch that does not follow the Conventional Branch
+# specification. https://conventionalbranch.org/
+
+pattern='^(main|master|develop|(feature|feat|bugfix|fix|hotfix|release|chore|ai|copilot|cursor|claude|codex)/[a-z0-9]+(\.[a-z0-9]+)*(-[a-z0-9]+(\.[a-z0-9]+)*)*)$'
+branch=$(git symbolic-ref --short HEAD)
+
+if ! printf '%s' "$branch" | grep -qE "$pattern"; then
+  echo "Branch '$branch' does not follow the Conventional Branch specification." >&2
+  echo "Expected <type>/<description>, for example feature/add-login-page." >&2
+  echo "See https://conventionalbranch.org/" >&2
+  exit 1
+fi
+```
+
+This is the only place on this page where the expression differs from `spec.json`, and
+only in that the non-capturing groups `(?:` are written as plain `(`. POSIX `grep -E`
+does not understand `(?:`, and `grep -P` is a GNU extension that macOS does not ship —
+on a Mac it would fail to run and reject *every* branch. The conformance check verifies
+that this form is the mechanical translation of the published expression and that it
+accepts exactly the same branch names.
+
+Git hooks are not copied by `git clone`. To share them with the team, commit the script
+to the repository and point Git at it once:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+### A branching alias
+
+Enforcement tells people they are wrong. An alias makes it easier to be right:
+
+```ini
+[alias]
+    feature = "!f() { git switch -c \"feature/$1\"; }; f"
+    bugfix  = "!f() { git switch -c \"bugfix/$1\"; }; f"
+    hotfix  = "!f() { git switch -c \"hotfix/$1\"; }; f"
+    chore   = "!f() { git switch -c \"chore/$1\"; }; f"
+```
+
+```bash
+git feature add-login-page   # creates and switches to feature/add-login-page
+```
+
+## AI coding agents
+
+Agents open pull requests now, which makes their branch names your branch names. Two
+ways to teach them the convention.
+
+### The agent skill
+
+```bash
+npx skills add conventional-branch/conventional-branch --skill conventional-branch
+```
+
+### A snippet for `AGENTS.md` or `CLAUDE.md`
+
+This is how most projects using the specification instruct their agents. Paste it into
+whichever instruction file your tooling reads:
+
+```markdown
+## Branch naming
+
+Branch names follow the [Conventional Branch](https://conventionalbranch.org/)
+specification: `<type>/<description>`, lowercase, hyphen-separated.
+
+Types: `feature/` (or `feat/`), `bugfix/` (or `fix/`), `hotfix/`, `release/`, `chore/`.
+`main`, `master` and `develop` take no prefix.
+
+Examples: `feature/add-login-page`, `bugfix/fix-header-overflow`, `release/v1.2.0`.
+
+When you create a branch yourself rather than at a person's direction, prefix it with
+your own agent name instead — `claude/`, `codex/`, `copilot/`, `cursor/`, or the
+vendor-neutral `ai/` — so the branch records who wrote it.
+```
+
+## Any other platform
+
+The portable artifact is the regular expression, and the most reliable way to get it is
+from the specification itself rather than by copying it out of a document:
+
+```python
+import json, re, urllib.request
+
+SPEC = "https://conventionalbranch.org/v1.1.0/spec.json"  # pinned, never changes
+
+spec = json.load(urllib.request.urlopen(SPEC))
+valid = re.compile(spec["grammar"]["regex"])
+
+print(bool(valid.fullmatch("feature/add-login-page")))  # True
+```
+
+If you are implementing validation in a tool, run it against
+[`fixtures.json`](https://github.com/conventional-branch/conventional-branch/blob/main/tests/fixtures.json)
+as well, so your behavior matches every other implementation.

--- a/content/enforce/index.md
+++ b/content/enforce/index.md
@@ -224,15 +224,21 @@ Enforcement tells people they are wrong. An alias makes it easier to be right:
 
 ```ini
 [alias]
-    feature = "!f() { git switch -c \"feature/$1\"; }; f"
-    bugfix  = "!f() { git switch -c \"bugfix/$1\"; }; f"
-    hotfix  = "!f() { git switch -c \"hotfix/$1\"; }; f"
-    chore   = "!f() { git switch -c \"chore/$1\"; }; f"
+    feature = "!f() { git switch -c \"feature/$(printf '%s' \"$*\" | tr 'A-Z _' 'a-z--')\"; }; f"
+    bugfix  = "!f() { git switch -c \"bugfix/$(printf '%s' \"$*\" | tr 'A-Z _' 'a-z--')\"; }; f"
+    hotfix  = "!f() { git switch -c \"hotfix/$(printf '%s' \"$*\" | tr 'A-Z _' 'a-z--')\"; }; f"
+    chore   = "!f() { git switch -c \"chore/$(printf '%s' \"$*\" | tr 'A-Z _' 'a-z--')\"; }; f"
 ```
 
 ```bash
-git feature add-login-page   # creates and switches to feature/add-login-page
+git feature add login page   # creates and switches to feature/add-login-page
+git feature Fix_Header       # creates and switches to feature/fix-header
 ```
+
+The `tr` handles the three ways people usually get it wrong without noticing:
+uppercase, underscores, and words typed with spaces instead of hyphens. It is a
+convenience rather than a check — a description with other punctuation in it still
+gets through, which is what the hook above is for.
 
 ## AI coding agents
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -40,7 +40,12 @@ python3 tests/conformance.py
 4. **Badge** — the version rendered in `static/badge.svg` is the version
    `spec.json` declares, so the adoption badge cannot go stale.
 5. **Schema** — `spec.json` and every frozen copy satisfy `schema/v1`.
-6. **Versioning** — the version `spec.json` declares has a byte-identical
+6. **Integrations** — every regex in the copy-pasteable configuration on
+   [`content/enforce/index.md`](../content/enforce/index.md) is the spec's own,
+   character for character. The one snippet that cannot use it verbatim — the
+   POSIX `grep -E` hook, which has no `(?:` — is additionally checked to accept
+   exactly the same branch names.
+7. **Versioning** — the version `spec.json` declares has a byte-identical
    frozen copy under `static/v<version>/`, so a release cannot ship without the
    permanent endpoint that downstream tools pin to.
 

--- a/tests/conformance.py
+++ b/tests/conformance.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Conformance test for the Conventional Branch specification.
 
-Runs six checks, all driven by the canonical machine-readable spec
+Runs seven checks, all driven by the canonical machine-readable spec
 (static/spec.json) so the docs, the registry and the grammar cannot drift
 apart silently:
 
@@ -15,7 +15,10 @@ apart silently:
                    spec.json declares, so the adoption badge cannot go stale.
   5. Schema      — spec.json, and every frozen copy of it, satisfies
                    static/schema/v1/spec.schema.json.
-  6. Versioning  — the version spec.json declares has a frozen, byte-identical
+  6. Integrations— every regex in the copy-pasteable configuration on
+                   content/enforce/index.md is the spec's own, character for
+                   character, so published configs cannot silently rot.
+  7. Versioning  — the version spec.json declares has a frozen, byte-identical
                    copy under static/v<version>/, so the permanent endpoint
                    downstream tools pin to cannot be forgotten on a release.
 
@@ -33,6 +36,7 @@ SPEC = STATIC / "spec.json"
 SCHEMA = STATIC / "schema" / "v1" / "spec.schema.json"
 FIXTURES = ROOT / "tests" / "fixtures.json"
 SPEC_PAGE = ROOT / "content" / "_index.md"
+ENFORCE_PAGE = ROOT / "content" / "enforce" / "index.md"
 AGENTS = ROOT / "data" / "agents.yaml"
 BADGE = STATIC / "badge.svg"
 
@@ -276,6 +280,61 @@ def check_schema(spec):
     return failures
 
 
+# Every copy of the validator on the enforcement page starts one of these two ways.
+# A line containing either is claiming to be the spec regex and has to be exactly it.
+REGEX_MARKERS = ("^(?:main|master|develop", "^(main|master|develop")
+
+
+def posix_ere(regex):
+    """The spec regex as POSIX ERE, for `grep -E` in the dependency-free hook.
+
+    `(?:` is the only construct in the published expression that POSIX does not
+    have, and turning it into a plain group changes nothing about what matches —
+    the groups are never referenced. `grep -P` would avoid the translation, but it
+    is a GNU extension: on macOS it fails to run, and `! grep -qP` then rejects
+    every branch name there is.
+    """
+    return regex.replace("(?:", "(")
+
+
+def check_integrations(spec, pattern):
+    """The enforcement page hands out copy-pasteable configuration, which is only
+    worth publishing if it cannot rot. Each embedded regex must be the spec's own,
+    character for character, in whichever of the three encodings its snippet needs.
+    The POSIX form is additionally checked to accept exactly the same branch names,
+    so the translation cannot quietly change meaning."""
+    regex = spec["grammar"]["regex"]
+    ere = posix_ere(regex)
+    accepted = (regex, json.dumps(regex)[1:-1], ere)
+    failures = []
+    found = 0
+
+    for number, line in enumerate(ENFORCE_PAGE.read_text(encoding="utf-8").splitlines(), 1):
+        if not any(marker in line for marker in REGEX_MARKERS):
+            continue
+        found += 1
+        if not any(form in line for form in accepted):
+            failures.append(
+                f"content/enforce/index.md:{number}: this regex is not the one in "
+                f"spec.json — a config on that page would accept the wrong branches"
+            )
+    if not found:
+        failures.append(
+            "content/enforce/index.md: no validator regex found — did the page move, "
+            "or did every snippet lose the pattern it is supposed to configure?"
+        )
+
+    compiled = re.compile(ere)
+    for case in json.loads(FIXTURES.read_text(encoding="utf-8"))["cases"]:
+        branch = case["branch"]
+        if (compiled.fullmatch(branch) is not None) != (pattern.fullmatch(branch) is not None):
+            failures.append(
+                f"the POSIX form of the regex disagrees with the spec on {branch!r} — "
+                f"the shell hook would not match the specification"
+            )
+    return found, failures
+
+
 def check_versioning(spec):
     """Downstream tools pin /v<version>/spec.json, so releasing a new version
     without freezing a copy of it would break the promise that URL makes."""
@@ -341,6 +400,16 @@ def main():
         f"schema:      {len(failures)} problem(s)"
         if failures
         else f"schema:      ok ({n} document(s) satisfy schema/v1)"
+    )
+    for f in failures:
+        print(f"  ✗ {f}")
+
+    n, failures = check_integrations(spec, pattern)
+    ok &= not failures
+    print(
+        f"integrations: {len(failures)} problem(s)"
+        if failures
+        else f"integrations: ok ({n} configs embed the spec regex verbatim)"
     )
     for f in failures:
         print(f"  ✗ {f}")

--- a/themes/conventional-branch/layouts/partials/header.html
+++ b/themes/conventional-branch/layouts/partials/header.html
@@ -35,6 +35,11 @@
       </li>
       <li class="header__menu-item dropdown">
         <button class="dropdown__label">
+          <a href="/enforce" class="no-style-a">Enforce</a>
+        </button>
+      </li>
+      <li class="header__menu-item dropdown">
+        <button class="dropdown__label">
           <a href="/about" class="no-style-a">About</a>
         </button>
       </li>


### PR DESCRIPTION
Every project that adopts the specification writes the same enforcement by hand. Of the 29 adopters on the About page, **every single one hand-wrote its own paragraph** — that is the strongest evidence this page should exist.

New page at [`/enforce/`](https://conventionalbranch.org/enforce/), linked from the header.

## What's on it

| Platform | What it gives you |
|---|---|
| **GitHub** | A ruleset JSON using `branch_name_pattern` with `operator: regex` — rejects the branch outright. Plus a Actions job for when a ruleset isn't an option. |
| **GitLab** | The push-rule regex (`pre-receive`, cannot be bypassed), plus a CI job for the Free tier. |
| **Bitbucket** | A Pipelines step, with an honest note that Cloud cannot block the push. |
| **Local** | `pre-commit` via commit-check, a dependency-free `pre-push` hook, and `.gitconfig` aliases. |
| **AI agents** | The skill, plus a paste-ready `AGENTS.md` / `CLAUDE.md` snippet. |

That last row came out of the adopter search: four of them — including `gchq/Bailo` and both `amagovpt` repos — document the convention for their *agents* rather than for people. It wasn't in the original plan for this page.

## The check that makes it safe to publish

Published configuration is a liability the moment it drifts from the spec. A seventh conformance check requires every regex on the page to be `spec.json`'s own, character for character, in whichever encoding its snippet needs (raw, JSON-escaped, or POSIX).

The shell hook is the one exception: POSIX `grep -E` has no `(?:`, so it carries the mechanical translation — and the check verifies that translation **accepts exactly the same 34 fixtures** rather than trusting it.

Negative-tested three ways: dropping a type from a regex, adding one, and removing the anchor. Each fails the build with the file and line.

## A real bug, caught by running it

The hook originally used `grep -P`. **macOS does not ship it.** Since the script branches on `! grep -qP`, a failure to *run* reads as a failed *match* — the hook would have rejected every branch on every Mac. Found by executing it, not by reading it.

## Verification

Each snippet was run, not merely written:

- **GitHub ruleset JSON** validated against GitHub's own OpenAPI schema for `POST /repos/{owner}/{repo}/rulesets` — **0 errors**. (The schema also corrected an earlier assumption of mine: `branch_name_pattern` is a first-class rule with a `regex` operator, so no `~ALL` + exclude-pattern workaround is needed.)
- **Hook** executed by BSD `grep -E` against all 34 fixtures — 34/34 — and end-to-end in a scratch git repo (`Feature/Bad` and `my_branch` rejected, `main` and `release/v1.2.0` accepted).
- **Aliases** run from the published `.gitconfig` text; the branches they create validate against the spec.
- **The published regex compiles under RE2** (all 34 fixtures agree), which is what makes one string safe to hand to GitHub, GitLab, Go and Python alike — and rules out catastrophic backtracking.
- All links on the page return 200; the pinned `/v1.1.0/spec.json` was fetched and used to validate a branch name.
- `hugo` builds the page with 15 code blocks and 6 sections; header nav renders.
- `python3 tests/conformance.py` — all seven checks pass.

## Platform limits stated where they bite

- GitLab push rules need **Premium or Ultimate** (docs: "Tier: Premium, Ultimate"). Free tier gets the CI job.
- GitLab always allows the default branch, and matches in multiline mode.
- Bitbucket **Cloud** cannot run arbitrary server-side hooks — Pipelines reports, it does not block.
- GitHub rulesets: public repos on every plan; private repos need Pro/Team/Enterprise Cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Enforce” page with copy-pasteable configurations for GitHub, GitLab, Bitbucket, pre-commit, Git hooks, aliases, and AI coding agents.
  * Added an “Enforce” link to the site navigation.
  * Included setup guidance and examples for validating branch names locally, in CI, and on code hosting platforms.

* **Documentation**
  * Documented integration validation against the canonical branch-naming specification.
  * Updated the changelog and README with the new enforcement resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->