### PR TITLE
fix(seo): give each page its own title, language and canonical

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,11 +1,21 @@
 baseURL: /
 languageCode: en-us
 theme: conventional-branch
+
+# Nothing in content/ is tagged or categorised, so Hugo was generating /categories/ and
+# /tags/ with no template to render them: an index.xml and no index.html, which is a 404
+# that the sitemap was nonetheless advertising to search engines.
+disableKinds: ["taxonomy", "term"]
 # defaultContentLanguageInSubdir: true
 defaultContentLanguage: en
 
 # Global parameters
 params:
+  # baseURL stays "/" so a Netlify deploy preview serves its own assets. canonical,
+  # og:url and og:image still have to be absolute, and always name production: a
+  # preview that made itself canonical would compete with the real site in the index.
+  canonicalBaseURL: https://conventionalbranch.org/
+
   license:
     title: License
     action:

--- a/config.yaml
+++ b/config.yaml
@@ -37,6 +37,7 @@ languages:
     params:
       weight: 1
       languageName: English
+      ogLocale: en_US
       title: Conventional Branch
       description: A specification for adding human and machine readable meaning to branch
       actions:
@@ -52,6 +53,7 @@ languages:
     params:
       weight: 2
       languageName: 中文
+      ogLocale: zh_CN
       title: 约定式分支
       description: 一种用于给分支增加人机可读含义的规范
       actions:
@@ -65,6 +67,7 @@ languages:
     params:
       weight: 3
       languageName: Português brasileiro
+      ogLocale: pt_BR
       title: Conventional Branch
       description: Uma especificação para dar aos nomes dos branches um significado legível para humanos e máquinas
       actions:
@@ -78,6 +81,7 @@ languages:
     params:
       weight: 4
       languageName: Français
+      ogLocale: fr_FR
       title: Conventional Branch
       description: Une spécification pour ajouter un sens lisible par l'humain et la machine aux branches
       actions:
@@ -91,6 +95,7 @@ languages:
     params:
       weight: 5
       languageName: 日本語
+      ogLocale: ja_JP
       title: 慣例的ブランチ
       description: ブランチに人間と機械が読める意味を追加する仕様
       actions:
@@ -104,6 +109,7 @@ languages:
     params:
       weight: 6
       languageName: Deutsch
+      ogLocale: de_DE
       title: Conventional Branch
       description: Eine Spezifikation zur Ergänzung von menschen- und maschinenlesbarer Bedeutung für Branches
       actions:
@@ -117,6 +123,7 @@ languages:
     params:
       weight: 7
       languageName: Русский
+      ogLocale: ru_RU
       title: Conventional Branch
       description: Спецификация для добавления человеко- и машиночитаемого смысла к веткам
       actions:
@@ -130,6 +137,7 @@ languages:
     params:
       weight: 8
       languageName: Polski
+      ogLocale: pl_PL
       title: Conventional Branch
       description: Specyfikacja dodawania znaczenia czytelnego dla ludzi i maszyn do gałęzi
       actions:
@@ -143,6 +151,7 @@ languages:
     params:
       weight: 9
       languageName: 繁體中文
+      ogLocale: zh_TW
       title: 約定式分支
       description: 一種為 Git branch 增添人機可讀含義的規範
       actions:
@@ -156,6 +165,7 @@ languages:
     params:
       weight: 10
       languageName: Español
+      ogLocale: es_ES
       title: Conventional Branch
       description: Una especificación para añadir significado legible por humanos y máquinas a las ramas
       actions:
@@ -169,6 +179,7 @@ languages:
     params:
       weight: 11
       languageName: ภาษาไทย
+      ogLocale: th_TH
       title: Conventional Branch
       description: ข้อกำหนดสำหรับการเพิ่มความหมายที่ทั้งมนุษย์และเครื่องจักรสามารถอ่านได้ให้กับชื่อ Branch
       actions:

--- a/content/_index.md
+++ b/content/_index.md
@@ -2,6 +2,8 @@
 draft: false
 aliases: ["/en/"]
 layout: single
+seoTitle: "Conventional Branch — A Git Branch Naming Convention"
+seoDescription: "A specification for Git branch names: feature/, bugfix/, hotfix/, release/ and chore/ prefixes, with a formal grammar and tooling to enforce them."
 ---
 
 # Conventional Branch 1.1.0

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -1,6 +1,8 @@
 ---
 type: about
 draft: false
+seoTitle: "AI Agent Branch Prefixes — Conventional Branch"
+seoDescription: "The registry of AI coding agent branch prefixes — ai/, claude/, codex/, copilot/, cursor/ — with tooling, CI/CD patterns and the projects using the specification."
 ---
 
 # About

--- a/content/enforce/index.md
+++ b/content/enforce/index.md
@@ -1,6 +1,8 @@
 ---
 type: about
 draft: false
+seoTitle: "Enforce Git Branch Naming — Conventional Branch"
+seoDescription: "Copy-pasteable branch name validation for GitHub rulesets, GitLab push rules, Bitbucket Pipelines and a dependency-free Git hook, using the published regex."
 ---
 
 # Enforcing Conventional Branch

--- a/themes/conventional-branch/layouts/_default/single.html
+++ b/themes/conventional-branch/layouts/_default/single.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{ .Site.Language.Lang }}">
 {{- partial "head.html" . -}}
 <body class="conventional-branch--loading">
 {{- partial "header.html" . -}}

--- a/themes/conventional-branch/layouts/_default/sitemap.xml
+++ b/themes/conventional-branch/layouts/_default/sitemap.xml
@@ -1,0 +1,13 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+{{/* As with sitemapindex.xml: <loc> has to be absolute, and baseURL is "/", so the host
+     comes from canonicalBaseURL rather than from Hugo's own permalinks. */}}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {{- range .Pages }}
+  <url>
+    <loc>{{ printf "%s%s" $.Site.Params.canonicalBaseURL (strings.TrimPrefix "/" .RelPermalink) }}</loc>
+    {{- if not .Lastmod.IsZero }}
+    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>
+    {{- end }}
+  </url>
+  {{- end }}
+</urlset>

--- a/themes/conventional-branch/layouts/_default/sitemapindex.xml
+++ b/themes/conventional-branch/layouts/_default/sitemapindex.xml
@@ -1,0 +1,11 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+{{/* The sitemap protocol requires an absolute <loc>, and baseURL is "/" so that a deploy
+     preview serves its own assets. Hugo's built-in template would emit "/en/sitemap.xml",
+     which Search Console rejects outright, so the host is prefixed explicitly here. */}}
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {{- range . }}
+  <sitemap>
+    <loc>{{ printf "%s%s" .Params.canonicalBaseURL (strings.TrimPrefix "/" .SitemapAbsURL) }}</loc>
+  </sitemap>
+  {{- end }}
+</sitemapindex>

--- a/themes/conventional-branch/layouts/about/single.html
+++ b/themes/conventional-branch/layouts/about/single.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{ .Site.Language.Lang }}">
 {{- partial "head.html" . -}}
 <body class="conventional-branch--loading">
 {{- partial "header.html" . -}}

--- a/themes/conventional-branch/layouts/partials/head.html
+++ b/themes/conventional-branch/layouts/partials/head.html
@@ -1,4 +1,7 @@
 <head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1,maximum-scale=1,user-scalable=no">
+
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-RH9YBHW509"></script>
   <script>
@@ -8,26 +11,61 @@
 
     gtag('config', 'G-RH9YBHW509');
   </script>
-  
+
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
   <link rel="stylesheet" href="{{ .Site.BaseURL }}css/style.css">
 
-  <title>{{ .Param "Title" }}</title>
-  <meta name="description" content="{{ .Param "Description" }}"/>
-  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1,maximum-scale=1,user-scalable=no">
+  {{/* The hero renders .Param "Title" and "Description" — the site's name and tagline,
+       identical on every page. A search result has to tell one page from another, so the
+       document title and description come from the page's own seoTitle/seoDescription
+       where it sets them, leaving the visible heading alone.
+
+       Archived specifications carry a `version` param and fold it into their title, so
+       every language's copy of an old version is distinguishable from the current one it
+       would otherwise share a title with. One rule covers all eleven translations, and
+       covers whatever version is archived next without needing to be touched. */}}
+  {{- $title := .Param "seoTitle" | default (.Param "Title") -}}
+  {{- with .Param "version" -}}
+    {{- $title = printf "%s %s" $title (strings.TrimPrefix "v" .) -}}
+  {{- end -}}
+  {{- $description := .Param "seoDescription" | default (.Param "Description") -}}
+
+  {{/* baseURL is "/" so that a Netlify deploy preview serves its own assets rather than
+       production's. Absolute URLs are built from an explicit host instead: canonical, og:url
+       and og:image have to be absolute to mean anything, and pointing them at production
+       from a preview is what keeps preview URLs from competing in the index. */}}
+  {{- $base := .Site.Params.canonicalBaseURL -}}
+  {{- $canonical := printf "%s%s" $base (strings.TrimPrefix "/" .RelPermalink) -}}
+  {{- $image := printf "%simg/git-flow-welcome.png" $base -}}
+
+  <title>{{ $title }}</title>
+  <meta name="description" content="{{ $description }}"/>
+  <link rel="canonical" href="{{ $canonical }}"/>
+
+  {{/* Eleven translations of one specification. Without these the only thing telling them
+       apart is the prose, and the wrong language can be served — or they can be read as
+       duplicates of each other. Each set is self-referential, as hreflang requires. */}}
+  {{- if .IsTranslated }}
+  {{- range .AllTranslations }}
+  <link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ printf "%s%s" $base (strings.TrimPrefix "/" .RelPermalink) }}"/>
+  {{- end }}
+  {{- end }}
 
   <!-- Twitter Card data -->
-  <meta name="twitter:card" content="{{ .Param "Description" }}">
-  <meta name="twitter:title" content="{{ .Param "Title" }}">
-  <meta name="twitter:description" content="{{ .Param "Description" }}">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{ $title }}">
+  <meta name="twitter:description" content="{{ $description }}">
+  <meta name="twitter:image" content="{{ $image }}">
 
   <!-- Open Graph data -->
-  <meta property="og:title" content="{{ .Param "Title" }}"/>
-  <meta property="og:type" content="article"/>
-  <meta property="og:url" content="{{ .Permalink }}"/>
-  <meta property="og:description" content="{{ .Param "Description" }}"/>
+  <meta property="og:title" content="{{ $title }}"/>
+  <meta property="og:type" content="{{ cond .IsHome "website" "article" }}"/>
+  <meta property="og:url" content="{{ $canonical }}"/>
+  <meta property="og:description" content="{{ $description }}"/>
   <meta property="og:site_name" content="{{ .Param "Title" }}"/>
+  <meta property="og:image" content="{{ $image }}"/>
+  <meta property="og:locale" content="{{ .Site.Language.Lang }}"/>
 </head>

--- a/themes/conventional-branch/layouts/partials/head.html
+++ b/themes/conventional-branch/layouts/partials/head.html
@@ -67,5 +67,13 @@
   <meta property="og:description" content="{{ $description }}"/>
   <meta property="og:site_name" content="{{ .Param "Title" }}"/>
   <meta property="og:image" content="{{ $image }}"/>
-  <meta property="og:locale" content="{{ .Site.Language.Lang }}"/>
+  {{/* Open Graph wants language_TERRITORY with an underscore, which is not the hyphenated
+       BCP-47 tag hreflang and the lang attribute take, so the territory is named per
+       language in config.yaml rather than derived from the language key. */}}
+  <meta property="og:locale" content="{{ .Site.Params.ogLocale | default "en_US" }}"/>
+  {{- if .IsTranslated }}
+  {{- range .Translations }}
+  <meta property="og:locale:alternate" content="{{ .Site.Params.ogLocale | default "en_US" }}"/>
+  {{- end }}
+  {{- end }}
 </head>


### PR DESCRIPTION
Technical SEO defects only — no content or keyword work, and no visual change.

## What was wrong

**Every page shared one `<title>` and one meta description.** `head.html` read `.Param "Title"`, no page set one in front matter, so all of them fell through to the site name in `config.yaml`. `/enforce/` — the page that answers "how do I validate branch names", with copy-pasteable configs for four platforms — was titled `Conventional Branch` and described with the spec's tagline. Google had nothing to tell it apart from the home page.

**The sitemap advertised 404s.** `/categories/` and `/tags/` were listed but have no template, so Hugo emitted an `index.xml` and no `index.html` for them — two dead URLs per language. `<loc>` was also relative (`/en/sitemap.xml`), which the sitemap protocol does not allow and Search Console rejects.

**Eleven translations had no language signals at all** — no `lang` on `<html>`, no `hreflang` — so they were readable as duplicates of one another rather than as translations, and the wrong language could be served.

**`twitter:card` contained the page description**, where the field takes `summary` or `summary_large_image`. The cards could not have been rendering. There was also no `og:image`, so link previews were bare.

## Approach

Titles come from a page's own `seoTitle`/`seoDescription`. The hero still renders `.Param "Title"`, so **the visible heading is unchanged** — the document title needed to be able to differ from the on-page heading, not replace it. Archived specs fold their existing `version` param into the title from a single rule, so all eleven translations of 1.0.0 are distinct from the current spec without touching eleven files, and whatever is archived next is covered automatically.

`baseURL` deliberately stays `/`. Setting it absolute would fix canonical and the sitemap for free, but it would also point the deploy preview's stylesheet, JS bundle and **language switcher** (`header.html:32` uses `.Permalink`) at production — a preview that can't be used to review translations. Absolute URLs come from a `canonicalBaseURL` param instead, which also means a preview's canonical names production rather than competing with it.

## Verification

Built with the pinned Hugo 0.128.0 (same version as `main.yml`) and inspected the generated HTML — the template changes are not the kind of thing to ship unbuilt.

| | before | after |
|---|---|---|
| `/` | `Conventional Branch` | `Conventional Branch — A Git Branch Naming Convention` |
| `/about/` | `Conventional Branch` | `AI Agent Branch Prefixes — Conventional Branch` |
| `/enforce/` | `Conventional Branch` | `Enforce Git Branch Naming — Conventional Branch` |
| `/v1.0.0/` | `Conventional Branch` | `Conventional Branch 1.0.0` |

- [x] Build clean — 25 pages, and the pre-existing `no layout file for "html" for kind "taxonomy"` warning is gone.
- [x] Every one of the 24 page URLs across all sitemaps resolves to a file on disk (was: 2 dead per language).
- [x] `hreflang` emits all 11 languages, self-referential as required, on translated pages only — `/about/` and `/enforce/` correctly emit none.
- [x] Archived translations differentiate in their own language (`約定式分支 1.0.0`, `慣例的ブランチ 1.0.0`).
- [x] Visible `<h1>` still `Conventional Branch`; `/css/style.css`, `/js/bundle.js` and the language switcher still root-relative, so previews are unaffected.
- [x] `python3 tests/conformance.py` — 9/9, since this adds front matter to files the check parses.

## Not in this PR

Seven translations (de, es, fr, pl, pt-br, ru, th) keep the English brand name as their `config.yaml` title, so they still share a title with each other. `hreflang` now tells Google they are translations, and their descriptions already differ, so this is no longer a duplicate-content problem — but localised titles want native-speaker judgement rather than my guess, so I have left them alone.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BudWCHvNNE2HPG5wY5PET1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SEO titles and descriptions for key pages.
  * Added canonical URLs, social sharing metadata, language references, and page-specific images.
  * Added localized Open Graph metadata for supported languages.
  * Added XML sitemaps with canonical URLs and modification dates.
* **Bug Fixes**
  * Prevented unused taxonomy pages from being published.
  * Ensured HTML language attributes accurately reflect the site language.
  * Corrected sitemap and metadata URLs for production deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->